### PR TITLE
John Greenwood's feedback - February 2026

### DIFF
--- a/backend/src/conversation/handlers/compressedGuideHandler.js
+++ b/backend/src/conversation/handlers/compressedGuideHandler.js
@@ -5,10 +5,13 @@ export async function compressedGuideHandler({ session }) {
   const timeBudget = session.data.timeBudget;
   const effectiveMinutes = timeBudget === 5 ? 5 : 2;
   const guide = getCompressedGuide(effectiveMinutes);
+  const wasIgnored = session.data.ignoredDuringTimeSelection === true;
+  delete session.data.ignoredDuringTimeSelection;
 
   session.state = STATES.PQA_PROMPT;
+  const content = [guide, CHALLENGE_PROMPT].join("\n\n");
   return {
-    reply: [guide, CHALLENGE_PROMPT].join("\n\n"),
+    reply: wasIgnored ? `Vaya joya.\n\n${content}` : content,
     state: session.state
   };
 }

--- a/backend/src/conversation/handlers/timeSelectionHandler.js
+++ b/backend/src/conversation/handlers/timeSelectionHandler.js
@@ -25,7 +25,7 @@ export async function timeSelectionHandler({ session, message }) {
 
   if (!minutes) {
     return {
-      reply: "Por favor, responde con 2, 5 o 15 minutos.",
+      reply: "Por favor, responde con 2 o 5 minutos.",
       state: session.state
     };
   }

--- a/backend/src/conversation/handlers/timeSelectionHandler.js
+++ b/backend/src/conversation/handlers/timeSelectionHandler.js
@@ -49,7 +49,10 @@ export async function timeSelectionHandler({ session, message }) {
     };
   }
 
-  // Valid → transition
+  // Valid → transition (remember if they were in "Ignorándote" phase for compressed guide)
+  const IGNORING_THRESHOLD = 10;
+  const wasIgnored = (session.data.timeSelectionAttempts ?? 0) >= IGNORING_THRESHOLD;
+  if (wasIgnored) session.data.ignoredDuringTimeSelection = true;
   session.state = STATES.COMPRESSED_GUIDE;
   session.data.timeBudget = minutes;
   delete session.data.timeSelectionAttempts;

--- a/backend/src/conversation/handlers/timeSelectionHandler.js
+++ b/backend/src/conversation/handlers/timeSelectionHandler.js
@@ -24,8 +24,27 @@ export async function timeSelectionHandler({ session, message }) {
   const minutes = parseTimeSelection(message);
 
   if (!minutes) {
+    const attempts = (session.data.timeSelectionAttempts ?? 0);
+    session.data.timeSelectionAttempts = attempts + 1;
+
+    const invalidReplies = [
+      "Por favor, responde con 2 o 5 minutos.",
+      "Por favor, dos o cinco minutos.",
+      "POR FAVOR, dos o cinco minutos.",
+      "¿Es en serio? 2 o 5.",
+      "2 o 5.",
+      "2 o 5.",
+      "2 o 5 por favor.",
+      "2 o 5, POR FAVOR.",
+      "Por Zeus. ¿Prefieres dos o cinco minutos? Ya habrías terminado.",
+      "Ya sabes lo que ofrezco. A partir de aquí te ignoro hasta que aclares si prefieres 2 o 5 minutos.",
+    ];
+    const reply = attempts >= invalidReplies.length
+      ? "Ignorándote."
+      : invalidReplies[attempts];
+
     return {
-      reply: "Por favor, responde con 2 o 5 minutos.",
+      reply,
       state: session.state
     };
   }
@@ -33,6 +52,7 @@ export async function timeSelectionHandler({ session, message }) {
   // Valid → transition
   session.state = STATES.COMPRESSED_GUIDE;
   session.data.timeBudget = minutes;
+  delete session.data.timeSelectionAttempts;
   return {
     reply: null,
     state: session.state

--- a/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.css
+++ b/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.css
@@ -48,6 +48,13 @@
     border: 0.5px solid black;
 }
 
+.blocked-session-modal__coming-soon-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 3;
+    background-color: rgba(0, 0, 0, 0.25);
+}
+
 @media (min-width: 1000px) {
     .blocked-session-modal {
         max-width: 500px;

--- a/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.jsx
+++ b/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.jsx
@@ -39,14 +39,14 @@ const BlockedSessionModal = ({ setOpenBlockedSessionModal, setIsSessionUnblocked
                 <div className="blocked-session-modal modal-fade-in">
                     <CloseIcon handleCloseModal={handleCloseBlockedSessionModal} />
                     <h3 className="blocked-session-modal__title">Desbloquear sesión #{selectedSession ? selectedSession.id : 0}</h3>
-                    <p className="blocked-session-modal__text">Opción 1 (Gratis):</p>
+                    <p className="blocked-session-modal__text"><strong>Compra el curso completo</strong> (15 sesiones + 15 ejercicios) por 15€</p>
+                    <button className="blocked-session-modal__button" onClick={() => setOpenComingSoonModal(true)}>COMPRAR</button>
+                    <hr className="blocked-session-modal__line"/>
+                    <p className="blocked-session-modal__text">Alternativa gratis:</p>
                     <p className="blocked-session-modal__text">Escríbenos a <strong>detoxmental4@gmail.com</strong> respondiéndo a la siguiente pregunta:</p>
                     <p className="blocked-session-modal__text blocked-session-modal__text--question">{selectedSession ? selectedSession.unblockQuestion : 0}</p>
                     <p className="blocked-session-modal__text">Nuestro equipo te dará un código para desbloquear esta sesión.</p>
-                    <button className="blocked-session-modal__button" onClick={() => setOpenEnterCodeModal(true)}>YA TENGO EL CÓDIGO</button>
-                    <hr className="blocked-session-modal__line"/>
-                    <p className="blocked-session-modal__text">Opción 2: Compra el curso completo (15 sesiones + 15 ejercicios) por 10€</p>
-                    <button className="blocked-session-modal__button blocked-session-modal__button--buy" onClick={() => setOpenComingSoonModal(true)}>COMPRAR</button>
+                    <button className="blocked-session-modal__button blocked-session-modal__button--buy" onClick={() => setOpenEnterCodeModal(true)}>YA TENGO EL CÓDIGO</button>
                     <span className="blocked-session-modal__close-text" onClick={handleCloseBlockedSessionModal}>Cerrar</span>
                 </div>
             </div>

--- a/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.jsx
+++ b/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.jsx
@@ -34,8 +34,20 @@ const BlockedSessionModal = ({ setOpenBlockedSessionModal, setIsSessionUnblocked
             <div className='modal-overlay modal-overlay--layer-2'>
                 <EnterCodeModal selectedSessionId={selectedSession.id} handleUnblockSession={handleUnblockSession} setOpenEnterCodeModal={setOpenEnterCodeModal}/>
             </div>}
-            {openComingSoonModal && <ComingSoonModal setOpenComingSoonModal={setOpenComingSoonModal}/>}
-            <div className='modal-overlay'>
+            {openComingSoonModal && (
+                <div
+                    className="blocked-session-modal__coming-soon-backdrop"
+                    onClick={() => setOpenComingSoonModal(false)}
+                >
+                    <div onClick={(e) => e.stopPropagation()}>
+                        <ComingSoonModal setOpenComingSoonModal={setOpenComingSoonModal}/>
+                    </div>
+                </div>
+            )}
+            <div
+                className='modal-overlay'
+                onClick={(e) => { if (e.target === e.currentTarget) setOpenBlockedSessionModal(false) }}
+            >
                 <div className="blocked-session-modal modal-fade-in">
                     <CloseIcon handleCloseModal={handleCloseBlockedSessionModal} />
                     <h3 className="blocked-session-modal__title">Desbloquear sesión #{selectedSession ? selectedSession.id : 0}</h3>

--- a/frontend/src/Components/ComingSoonModal/ComingSoonModal.css
+++ b/frontend/src/Components/ComingSoonModal/ComingSoonModal.css
@@ -31,7 +31,7 @@
   }
   to {
     opacity: 1;
-    transform: translate(-50%, -170%);
+    transform: translate(-49%, -170%);
   }
 }
 

--- a/frontend/src/Components/ComingSoonModal/ComingSoonModal.css
+++ b/frontend/src/Components/ComingSoonModal/ComingSoonModal.css
@@ -27,11 +27,11 @@
 @keyframes modalBuyCourseFadeIn {
   from {
     opacity: 0;
-    transform: translate(-50%, 155%);
+    transform: translate(-50%, -160%);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 145%);
+    transform: translate(-50%, -170%);
   }
 }
 

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -1,18 +1,33 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import './Navigation.css';
 import { useNavigate } from 'react-router-dom';
 
 const Navigation = () => {
     const [isLinksVisible, setIsLinksVisible] = useState(false);
+    const linksContainerRef = useRef(null);
     const navigate = useNavigate();
+
+    useEffect(() => {
+        if (!isLinksVisible) return;
+        const onDocumentClick = (e) => {
+            if (linksContainerRef.current && !linksContainerRef.current.contains(e.target)) {
+                setIsLinksVisible(false);
+            }
+        };
+        document.addEventListener('click', onDocumentClick);
+        return () => document.removeEventListener('click', onDocumentClick);
+    }, [isLinksVisible]);
+
     return (
         <div className="navigation">
-            {isLinksVisible && <div className='navigation__links-container'>
-                <span className='navigation__link' onClick={() => navigate('/')}>ARTÍCULO</span>
-                <hr/>
-                <span className='navigation__link' onClick={() => navigate('/course')}>CURSO</span>
-            </div>}
-            <img className="navigation__icon" src='/images/menu.svg' onClick={() => setIsLinksVisible(v => !v)}/>
+            {isLinksVisible && (
+                <div ref={linksContainerRef} className='navigation__links-container'>
+                    <span className='navigation__link' onClick={() => navigate('/')}>ARTÍCULO</span>
+                    <hr/>
+                    <span className='navigation__link' onClick={() => navigate('/course')}>CURSO</span>
+                </div>
+            )}
+            <img className="navigation__icon" src='/images/menu.svg' onClick={(e) => { e.stopPropagation(); setIsLinksVisible(v => !v); }} alt="" />
         </div>
     );
 }

--- a/frontend/src/Pages/Onboarding/Onboarding.jsx
+++ b/frontend/src/Pages/Onboarding/Onboarding.jsx
@@ -20,6 +20,7 @@ export default function Onboarding() {
   const [hasReachedExitButtons, setHasReachedExitButtons] = useState(false);
   const messagesEndRef = useRef(null);
   const exitButtonsRef = useRef(null);
+  const inputRef = useRef(null);
   const navigate = useNavigate();
   
   async function sendMessage(e) {
@@ -98,6 +99,16 @@ export default function Onboarding() {
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [loading, messages.length]);
+
+  useEffect(() => {
+    if (sessionState?.state === "EXIT") return;
+    if (loading) return;
+    if (!window.matchMedia("(min-width: 1000px)").matches) return;
+    const id = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [loading, sessionState?.state]);
 
   useEffect(() => {
     if (sessionState?.state !== "EXIT") return;
@@ -216,6 +227,7 @@ export default function Onboarding() {
       ) : (
         <form onSubmit={sendMessage}>
           <input
+            ref={inputRef}
             className="onboarding__input"
             value={input}
             onChange={e => setInput(e.target.value)}


### PR DESCRIPTION
# chore/john-feedback

Addresses John's feedback with UX and copy tweaks across onboarding, navigation, blocked-session modal, and backend time-selection handling.

## Changes (John's feedback)

### Navigation
- Menu closes when the user clicks outside the links (click-outside-to-close).

### Blocked session / Coming Soon modals
- Reordered unblock-session options. The paid alternative is now first and the free alternative is now second in the unblock session modal.
- Adjusted Coming Soon modal position and layout for desktop.
- Both modals close when clicking outside (overlay click), in addition to the close icon / "Cerrar".

### Backend
- **timeSelectionHandler:** Removed 15 minutes as a valid input control and updated validation.
- **compressedGuideHandler:** Small adjustment (logic/response).

## Outside of John's feedback—included in this PR for time optimization

- **Onboarding:** Input keeps focus on desktop so the user can keep typing without re-focusing.
- **Playful re-try logic:** When the user fails to input either 2 or 5 minutes as their time, Tales responds with several variations of "Por favor, indica si prefieres 2 o 5 minutos" until he seemingly loses his patience and decides to ignore the user.
- **"Vaya joya" message:** Ironic message from Tales if the user failed enough attempts to be ignored.

---

**Files touched:** Frontend — `Navigation.jsx`, `Onboarding.jsx`, `BlockedSessionModal` (JSX + CSS), `ComingSoonModal.css`. Backend — `timeSelectionHandler.js`, `compressedGuideHandler.js`.