### PR TITLE
Course instructions CTA

### DIFF
--- a/frontend/public/icons/instructions.svg
+++ b/frontend/public/icons/instructions.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="none">
+  <path d="M8 6.5h8M8 11.5h8M8 16.5h5" stroke="#F4F2F0" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M5.5 3.75h13A1.75 1.75 0 0 1 20.25 5.5v13a1.75 1.75 0 0 1-1.75 1.75h-13A1.75 1.75 0 0 1 3.75 18.5v-13A1.75 1.75 0 0 1 5.5 3.75Z" stroke="#F4F2F0" stroke-width="1.8"/>
+</svg>

--- a/frontend/src/Pages/Course/Course.css
+++ b/frontend/src/Pages/Course/Course.css
@@ -73,7 +73,25 @@
 
 .sessions-subtitle {
     margin-top: 0;
+    margin-bottom: 18px;
+}
+
+.sessions-instructions-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: auto;
+    min-width: 210px;
     margin-bottom: 50px;
+    padding: 12px 22px;
+    box-shadow: 0 6px 18px rgba(132, 93, 67, 0.18);
+}
+
+.sessions-instructions-button__icon {
+    width: 20px;
+    height: 20px;
+    flex: 0 0 auto;
 }
 
 .sessions-container {

--- a/frontend/src/Pages/Course/Course.jsx
+++ b/frontend/src/Pages/Course/Course.jsx
@@ -27,6 +27,10 @@ const Course = () => {
         }
     }
 
+    const handleGoToInstructions = () => {
+        navigate('/instructions');
+    }
+
     return (
         <div className='sessions-page'>
           {openBlockedSessionModal && <BlockedSessionModal setOpenBlockedSessionModal={setOpenBlockedSessionModal} setIsSessionUnblocked={setIsSessionUnblocked} setSessions={setSessions} selectedSession={selectedSession.current}/>}
@@ -43,6 +47,15 @@ const Course = () => {
             <Navigation />
             <h1 className='sessions-title'>Detox Mental</h1>
             <p className='sessions-subtitle'>Limpia tu mente escribiendo</p>
+            <button type='button' className='sessions-instructions-button' onClick={handleGoToInstructions}>
+                <img
+                    className='sessions-instructions-button__icon'
+                    src='/icons/instructions.svg'
+                    alt=''
+                    aria-hidden='true'
+                />
+                INSTRUCCIONES
+            </button>
             <div className="sessions-container">
                 {sessions.map((session, index) => (
                     <SessionCard session={session} key={index} handleGoToSession={handleGoToSession}/>


### PR DESCRIPTION
## Summary

Adds a visible `INSTRUCCIONES` call-to-action to the Course page so users who land on `/course` can easily navigate to the existing `/instructions` page before starting sessions. It was decided to include this button to increase conversion from first-time visitors to course doers.

## Changes

### Course page CTA
- Added an `INSTRUCCIONES` button below the Course subtitle that routes users to `/instructions`.
- Styled the CTA to match the existing rounded brown button aesthetic while preserving spacing before the session cards.
- Added a reusable `instructions.svg` icon under `frontend/public/icons` and references it from the Course page button.

## Test plan
- [x] Open `/course` and confirm the `INSTRUCCIONES` button appears below the subtitle.
- [x] Click the button and confirm it navigates to `/instructions`.
- [x] Confirm the icon renders correctly beside the button text.
- [ ] Run the frontend build before merging.