### PR TITLE
Update ThoughtsTest journaling actions to TERMINAR/CANCELAR

### DIFF
--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.css
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.css
@@ -1,9 +1,259 @@
-/* Promo-specific tweaks. Chat styling is reused from Onboarding.css. */
+/* ─── Chat layout ────────────────────────────────────────────────────────── */
 
-/* Leaves room for the fixed Navigation bar so content isn't hidden behind it. */
-.thoughts-test {
-  padding-bottom: 80px;
+.test-chat {
+  min-height: 100vh;
+  padding: 40px 1rem 80px;
 }
+
+@media (min-width: 1000px) {
+  .test-chat {
+    max-width: 700px;
+    margin: 0 auto;
+    padding: 40px 0 80px;
+  }
+}
+
+.test-chat__message-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.test-chat__message-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.test-chat__message-wrapper--user {
+  align-items: flex-end;
+}
+
+.test-chat__message__avatar {
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  object-position: center top;
+}
+
+.test-chat__message {
+  line-height: 25px;
+  word-break: break-word;
+  padding: 12px 16px;
+  border-radius: 18px;
+  background-color: #f8f8f8;
+  max-width: 90%;
+  border: 0.5px solid white;
+}
+
+.test-chat__message p {
+  margin-bottom: 8px;
+}
+
+.test-chat__message li {
+  list-style: unset;
+  list-style-position: inside;
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.test-chat__message__role {
+  display: block;
+}
+
+.test-chat__message--user {
+  text-align: left;
+  background-color: #ffeee494;
+}
+
+/* ─── Input & button ─────────────────────────────────────────────────────── */
+
+.test-chat__cta-box {
+  width: 95%;
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background-color: #fafafa;
+  border: 0.5px solid rgba(255, 255, 255, 0.9);
+  box-sizing: border-box;
+}
+
+.test-chat__cta-box form {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.test-chat__cta-box__title {
+  margin: 0 0 0.5rem;
+  font-size: 24px;
+  font-weight: 700;
+  color: #333;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.test-chat__cta-box__paragraph {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: #555;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.test-chat__cta-box .test-chat__input {
+  margin-bottom: 10px;
+}
+
+.test-chat__input {
+  width: 100%;
+  border-radius: 16px;
+  padding: 12px;
+  font-size: 18px;
+  border: 1.25px solid transparent;
+  background: linear-gradient(white, white) padding-box,
+    linear-gradient(
+        135deg,
+        #d4a574 0%,
+        #ffb5a7 25%,
+        #a8e6cf 50%,
+        #ffd89b 75%,
+        #c49564 100%
+      )
+      border-box;
+  background-clip: padding-box, border-box;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.test-chat__input:focus {
+  outline: none;
+}
+
+.test-chat__input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  animation: none;
+}
+
+.test-chat__button {
+  font-size: 18px;
+  font-weight: 400;
+  letter-spacing: 2px;
+  border: 2px solid transparent;
+  background: linear-gradient(#845d43, #845d43) padding-box,
+    linear-gradient(135deg, #d4a574 0%, #ffb5a7 25%, 50%, #ffd89b 75%, #c49564 100%)
+      border-box;
+  background-clip: padding-box, border-box;
+  border-radius: 16px;
+  padding: 12px 24px;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.test-chat__button:hover:not(:disabled) {
+  transform: scale(1.05);
+}
+
+.test-chat__button:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.test-chat__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  animation: none;
+}
+
+/* ─── Chips ──────────────────────────────────────────────────────────────── */
+
+.test-chat__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  width: 100%;
+}
+
+.test-chat__chip {
+  font-size: 0.9rem;
+  line-height: 1.35;
+  text-align: left;
+  padding: 10px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  border: 1.25px solid transparent;
+  background: linear-gradient(#fafafa, #fafafa) padding-box,
+    linear-gradient(
+        135deg,
+        #d4a574 0%,
+        #ffb5a7 25%,
+        #a8e6cf 50%,
+        #ffd89b 75%,
+        #c49564 100%
+      )
+      border-box;
+  background-clip: padding-box, border-box;
+  color: #333;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.test-chat__chip:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.test-chat__chip:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.test-chat__chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ─── Typing indicator ───────────────────────────────────────────────────── */
+
+.test-chat__loading-indicator {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.test-chat__loading-indicator span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #666;
+  animation: test-chat-bounce 1.4s infinite ease-in-out both;
+}
+
+.test-chat__loading-indicator span:nth-child(1) {
+  animation-delay: -0.32s;
+}
+
+.test-chat__loading-indicator span:nth-child(2) {
+  animation-delay: -0.16s;
+}
+
+@keyframes test-chat-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0);
+    opacity: 0.5;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* ─── Page-level elements ────────────────────────────────────────────────── */
 
 .thoughts-test__title {
   font-size: 24px;

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.css
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.css
@@ -23,6 +23,14 @@
   margin-top: 4px;
 }
 
+/* Inverted call-to-action used in the pre-writing journal state. */
+.thoughts-test__continue-button {
+  margin-top: 12px;
+  background: var(--background);
+  border: 2px solid var(--accent);
+  color: var(--accent);
+}
+
 /* Primary CTA for completing journaling. */
 .thoughts-test__journal-finish-button {
   margin-top: 12px;

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.css
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.css
@@ -23,9 +23,16 @@
   margin-top: 4px;
 }
 
-/* Inverted call-to-action: accent border and text over the page background,
-   the opposite of the filled onboarding buttons. */
-.thoughts-test__continue-button {
+/* Primary CTA for completing journaling. */
+.thoughts-test__journal-finish-button {
+  margin-top: 12px;
+  background: var(--accent);
+  border: 2px solid var(--accent);
+  color: var(--background);
+}
+
+/* Inverted secondary CTA for dismissing the writing box. */
+.thoughts-test__journal-cancel-button {
   margin-top: 12px;
   background: var(--background);
   border: 2px solid var(--accent);

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -5,7 +5,6 @@ import { thoughtsTests } from "../../data";
 import { saveThoughtsTestAnswer } from "../../utils/thoughtsTestStorage";
 import Navigation from "../../Components/Navigation/Navigation";
 import TestLoadingScreen from "./TestLoadingScreen";
-import "../Onboarding/Onboarding.css";
 import "./ThoughtsTest.css";
 
 const ROLE_LABELS = {
@@ -67,13 +66,13 @@ const JournalTimer = () => {
 function ChatMessage({ role, content }) {
   const isUser = role === "user";
   return (
-    <div className={"onboarding__message-wrapper" + (isUser ? " user-message-wrapper" : "")}>
+    <div className={"test-chat__message-wrapper" + (isUser ? " test-chat__message-wrapper--user" : "")}>
       {!isUser && (
-        <img src="/images/thales.webp" alt="Tales" className="onboarding__message__avatar" />
+        <img src="/images/thales.webp" alt="Tales" className="test-chat__message__avatar" />
       )}
-      <div className={"onboarding__message" + (isUser ? " user-message" : "")}>
-        <strong className="onboarding__message__role">{getRoleLabel(role)}:</strong>
-        <div className="onboarding__message__content">
+      <div className={"test-chat__message" + (isUser ? " test-chat__message--user" : "")}>
+        <strong className="test-chat__message__role">{getRoleLabel(role)}:</strong>
+        <div className="test-chat__message__content">
           {isUser ? (
             <span>{content}</span>
           ) : (
@@ -87,12 +86,12 @@ function ChatMessage({ role, content }) {
 
 function TypingBubble() {
   return (
-    <div className="onboarding__message-wrapper">
-      <img src="/images/thales.webp" alt="Tales" className="onboarding__message__avatar" />
-      <div className="onboarding__message onboarding__message--loading">
-        <strong className="onboarding__message__role">{getRoleLabel("assistant")}:</strong>
-        <div className="onboarding__message__content">
-          <div className="onboarding__loading-indicator">
+    <div className="test-chat__message-wrapper">
+      <img src="/images/thales.webp" alt="Tales" className="test-chat__message__avatar" />
+      <div className="test-chat__message test-chat__message--loading">
+        <strong className="test-chat__message__role">{getRoleLabel("assistant")}:</strong>
+        <div className="test-chat__message__content">
+          <div className="test-chat__loading-indicator">
             <span></span>
             <span></span>
             <span></span>
@@ -327,9 +326,9 @@ function ThoughtsTestChat() {
   const showPromo = phase === "done" && !recommendedTest;
 
   return (
-    <div className="onboarding thoughts-test">
+    <div className="test-chat thoughts-test">
       <h1 className="thoughts-test__title">Test: {test.title}</h1>
-      <div className="onboarding__message-container">
+      <div className="test-chat__message-container">
         {messages.map((m, i) => (
           <ChatMessage key={i} role={m.role} content={m.content} />
         ))}
@@ -338,12 +337,12 @@ function ThoughtsTestChat() {
       </div>
 
       {showChips && (
-        <div className="onboarding__chips" aria-label="Opciones de respuesta">
+        <div className="test-chat__chips" aria-label="Opciones de respuesta">
           {currentQuestion.options.map((option) => (
             <button
               key={option.id}
               type="button"
-              className="onboarding__chip"
+              className="test-chat__chip"
               disabled={loading}
               onClick={() => handleChipSelect(currentQuestion, option)}
             >
@@ -354,17 +353,17 @@ function ThoughtsTestChat() {
       )}
 
       {showTextForm && (
-        <div className="onboarding__cta-box">
+        <div className="test-chat__cta-box">
           <form onSubmit={handleTextSubmit}>
             <input
               ref={inputRef}
-              className="onboarding__input"
+              className="test-chat__input"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="Escribe tu respuesta"
               disabled={loading}
             />
-            <button className="onboarding__button" type="submit" disabled={loading}>
+            <button className="test-chat__button" type="submit" disabled={loading}>
               ENVIAR
             </button>
           </form>
@@ -378,7 +377,7 @@ function ThoughtsTestChat() {
             <div className="thoughts-test__write-intro">
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button"
+                className="test-chat__button thoughts-test__promo-button"
                 onClick={() => setWriteState("writing")}
               >
                 ESCRIBIR
@@ -401,14 +400,14 @@ function ThoughtsTestChat() {
               />
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button thoughts-test__journal-finish-button"
+                className="test-chat__button thoughts-test__promo-button thoughts-test__journal-finish-button"
                 onClick={handleContinue}
               >
                 TERMINAR
               </button>
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button thoughts-test__journal-cancel-button"
+                className="test-chat__button thoughts-test__promo-button thoughts-test__journal-cancel-button"
                 onClick={() => {
                   setWriteState("idle");
                   setJournalText("");
@@ -423,7 +422,7 @@ function ThoughtsTestChat() {
             <>
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button thoughts-test__continue-button"
+                className="test-chat__button thoughts-test__promo-button thoughts-test__continue-button"
                 onClick={handleContinue}
               >
                 CONTINUAR
@@ -447,7 +446,7 @@ function ThoughtsTestChat() {
           <ChatMessage role="assistant" content={test.recommendation.message} />
           <button
             type="button"
-            className="onboarding__button thoughts-test__promo-button"
+            className="test-chat__button thoughts-test__promo-button"
             onClick={() => navigate(`/test/${recommendedTestId}`)}
           >
             {recommendedTest.title}
@@ -456,12 +455,12 @@ function ThoughtsTestChat() {
       )}
 
       {showPromo && (
-        <div className="onboarding__cta-box thoughts-test__promo">
-          <h3 className="onboarding__cta-box__title">{test.coursePromo.title}</h3>
-          <p className="onboarding__cta-box__paragraph">{test.coursePromo.paragraph}</p>
+        <div className="test-chat__cta-box thoughts-test__promo">
+          <h3 className="test-chat__cta-box__title">{test.coursePromo.title}</h3>
+          <p className="test-chat__cta-box__paragraph">{test.coursePromo.paragraph}</p>
           <button
             type="button"
-            className="onboarding__button thoughts-test__promo-button"
+            className="test-chat__button thoughts-test__promo-button"
             onClick={() => navigate("/course")}
           >
             {test.coursePromo.buttonLabel}

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -260,6 +260,11 @@ function ThoughtsTestChat() {
         value: journalText.trim(),
       });
     }
+    // Hide the writing UI immediately after finishing the exercise.
+    if (writeState === "writing") {
+      setWriteState("idle");
+      setJournalText("");
+    }
     const recId = test.recommendation?.byOption[keyOptionRef.current] ?? null;
     const recTest = recId ? thoughtsTests[recId] : null;
     if (recTest) {

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -5,6 +5,7 @@ import { thoughtsTests } from "../../data";
 import { saveThoughtsTestAnswer } from "../../utils/thoughtsTestStorage";
 import Navigation from "../../Components/Navigation/Navigation";
 import TestLoadingScreen from "./TestLoadingScreen";
+import { getRandomJournalAcknowledgment } from "./loadingQuotes";
 import "./ThoughtsTest.css";
 
 const ROLE_LABELS = {
@@ -261,7 +262,7 @@ function ThoughtsTestChat() {
     if (didWrite) {
       setWriteState("idle");
       setJournalText("");
-      await talesSay("Me alegra que hayas podido escribir sobre esto. Espero que te haya ayudado.");
+      await talesSay(getRandomJournalAcknowledgment());
       if (!mountedRef.current) return;
     }
     const recId = test.recommendation?.byOption[keyOptionRef.current] ?? null;

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -236,7 +236,7 @@ function ThoughtsTestChat() {
       setStepIndex(nextIndex);
     } else {
       // All questions answered: reveal Tales' journaling prompt and wait for the
-      // user to press CONTINUAR (handleContinue) before closing with either a
+      // user to press TERMINAR (handleContinue) before closing with either a
       // recommendation or, as a fallback, the course promo.
       if (!mountedRef.current) return;
       setLoading(true);
@@ -397,7 +397,14 @@ function ThoughtsTestChat() {
               />
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button"
+                className="onboarding__button thoughts-test__promo-button thoughts-test__journal-finish-button"
+                onClick={handleContinue}
+              >
+                TERMINAR
+              </button>
+              <button
+                type="button"
+                className="onboarding__button thoughts-test__promo-button thoughts-test__journal-cancel-button"
                 onClick={() => {
                   setWriteState("idle");
                   setJournalText("");
@@ -408,14 +415,14 @@ function ThoughtsTestChat() {
             </div>
           )}
 
-          {phase === "journal" && !loading && (
+          {phase === "journal" && !loading && writeState !== "writing" && (
             <>
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button thoughts-test__continue-button"
+                className="onboarding__button thoughts-test__promo-button thoughts-test__journal-finish-button"
                 onClick={handleContinue}
               >
-                CONTINUAR
+                TERMINAR
               </button>
               <Link to="/" className="thoughts-test__home-link">
                 Ir al inicio

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -236,8 +236,8 @@ function ThoughtsTestChat() {
       setStepIndex(nextIndex);
     } else {
       // All questions answered: reveal Tales' journaling prompt and wait for the
-      // user to press TERMINAR (handleContinue) before closing with either a
-      // recommendation or, as a fallback, the course promo.
+      // user to continue/finish before closing with either a recommendation or,
+      // as a fallback, the course promo.
       if (!mountedRef.current) return;
       setLoading(true);
       await delay(TYPING_DELAY_MS);
@@ -419,10 +419,10 @@ function ThoughtsTestChat() {
             <>
               <button
                 type="button"
-                className="onboarding__button thoughts-test__promo-button thoughts-test__journal-finish-button"
+                className="onboarding__button thoughts-test__promo-button thoughts-test__continue-button"
                 onClick={handleContinue}
               >
-                TERMINAR
+                CONTINUAR
               </button>
               <Link to="/" className="thoughts-test__home-link">
                 Ir al inicio

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -235,14 +235,10 @@ function ThoughtsTestChat() {
       if (!mountedRef.current) return;
       setStepIndex(nextIndex);
     } else {
-      // All questions answered: reveal Tales' journaling prompt and wait for the
-      // user to continue/finish before closing with either a recommendation or,
-      // as a fallback, the course promo.
+      // All questions answered: add Tales' journaling prompt to the message
+      // thread, then switch to the journal phase for the writing controls.
+      await talesSay(test.journalingPrompt);
       if (!mountedRef.current) return;
-      setLoading(true);
-      await delay(TYPING_DELAY_MS);
-      if (!mountedRef.current) return;
-      setLoading(false);
       setPhase("journal");
     }
   }
@@ -251,8 +247,10 @@ function ThoughtsTestChat() {
   // reveals the closing recommendation, or the course promo when none applies.
   async function handleContinue() {
     if (loading || phase !== "journal") return;
+    // Capture before any state reset so the acknowledgment check is accurate.
+    const didWrite = writeState === "writing";
     // Save any in-progress journal text before advancing.
-    if (writeState === "writing" && journalText.trim()) {
+    if (didWrite && journalText.trim()) {
       saveThoughtsTestAnswer(testId, {
         questionId: "journal-entry",
         prompt: test.journalingPrompt,
@@ -260,10 +258,12 @@ function ThoughtsTestChat() {
         value: journalText.trim(),
       });
     }
-    // Hide the writing UI immediately after finishing the exercise.
-    if (writeState === "writing") {
+    // Hide the writing UI and acknowledge completion when the user actually wrote.
+    if (didWrite) {
       setWriteState("idle");
       setJournalText("");
+      await talesSay("Me alegra que hayas podido escribir sobre esto. Espero que te haya ayudado.");
+      if (!mountedRef.current) return;
     }
     const recId = test.recommendation?.byOption[keyOptionRef.current] ?? null;
     const recTest = recId ? thoughtsTests[recId] : null;
@@ -373,7 +373,6 @@ function ThoughtsTestChat() {
 
       {showJournal && (
         <div className="thoughts-test__journal">
-          <ChatMessage role="assistant" content={test.journalingPrompt} />
 
           {phase === "journal" && !loading && writeState === "idle" && (
             <div className="thoughts-test__write-intro">

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -375,7 +375,7 @@ function ThoughtsTestChat() {
         <div className="thoughts-test__journal">
           <ChatMessage role="assistant" content={test.journalingPrompt} />
 
-          {writeState === "idle" && (
+          {phase === "journal" && !loading && writeState === "idle" && (
             <div className="thoughts-test__write-intro">
               <button
                 type="button"

--- a/frontend/src/Pages/ThoughtsTest/loadingQuotes.js
+++ b/frontend/src/Pages/ThoughtsTest/loadingQuotes.js
@@ -11,3 +11,13 @@ export const loadingQuotes = [
 
 export const getRandomLoadingQuote = () =>
   loadingQuotes[Math.floor(Math.random() * loadingQuotes.length)];
+
+export const journalAcknowledgments = [
+  "Me alegra que hayas podido escribir sobre esto. Espero que te haya ayudado.",
+  "Bien, espero que escribir sobre el tema te haya ayudado a liberar un poco de estrés.",
+  "Escribir es mágico. Espero que te haya ayudado.",
+  "Qué bueno que te animaste a escribir. Un paso al frente para tu salud mental.",
+];
+
+export const getRandomJournalAcknowledgment = () =>
+  journalAcknowledgments[Math.floor(Math.random() * journalAcknowledgments.length)];

--- a/frontend/src/data/thoughtsTests.js
+++ b/frontend/src/data/thoughtsTests.js
@@ -81,7 +81,7 @@ export const thoughtsTests = {
 
   "future-thoughts-1": {
     id: "future-thoughts-1",
-    title: "Pensamientos sobre el futuro #1",
+    title: "Pensamientos del futuro #1",
     intro:
       "Vamos a explorar esos pensamientos sobre el futuro que te generan estrés. Responde con sinceridad: solo elige lo que más se parezca a tu experiencia.",
     questions: [
@@ -137,7 +137,7 @@ export const thoughtsTests = {
 
   "past-thoughts-1": {
     id: "past-thoughts-1",
-    title: "Pensamientos sobre el pasado #1",
+    title: "Pensamientos del pasado #1",
     intro:
       "Vamos a mirar esos pensamientos sobre el pasado que vuelven una y otra vez. No hay respuestas correctas: solo elige lo que más se parezca a tu experiencia.",
     questions: [
@@ -249,7 +249,7 @@ export const thoughtsTests = {
 
   "relationship-thoughts-1": {
     id: "relationship-thoughts-1",
-    title: "Pensamientos sobre los demás #1",
+    title: "Pensamientos sobre otros #1",
     intro:
       "Vamos a mirar esos pensamientos sobre tu relación con otras personas que te generan estrés. No hay respuestas correctas: solo elige lo que más se parezca a tu experiencia.",
     questions: [


### PR DESCRIPTION
## Summary

Refines the journaling UX in the ThoughtsTest flow by improving button hierarchy (TERMINAR/CANCELAR replacing a single CONTINUAR), adding a randomized acknowledgment message from Tales after the user writes, and migrating all chat UI classes off `onboarding__*` into a dedicated `test-chat__*` namespace.

## Changes

### Journaling button hierarchy
- Replaces the single CONTINUAR button in write mode with two explicit actions: **TERMINAR** (saves and advances) and **CANCELAR** (discards and returns to idle).
- Hides ESCRIBIR after the journal is completed so it doesn't re-appear.
- Shows CONTINUAR only while in the idle (non-writing) journal state.

### Post-journal acknowledgment
- Tales now speaks a randomly selected acknowledgment phrase after the user finishes writing, before the closing recommendation appears.
- Adds `journalAcknowledgments` array and `getRandomJournalAcknowledgment()` helper to `loadingQuotes.js`.

### CSS namespace migration
- Extracts an independent `ThoughtsTest.css` with `test-chat__*` BEM classes, fully replacing the inherited `onboarding__*` styles for the chat UI.
- Removes the `Onboarding.css` import from `ThoughtsTest.jsx`.

### Copy fixes
- Corrects test titles: "sobre el futuro/el pasado/los demás" → "del futuro / del pasado / sobre otros".

## Notes
- `test-chat__*` classes are scoped to `ThoughtsTest.css`; no changes to `Onboarding.css` itself.

## Test plan
- [ ] Complete a test through all question chips → journaling prompt appears in the chat thread.
- [ ] Click ESCRIBIR → textarea appears with TERMINAR and CANCELAR; CONTINUAR is hidden.
- [ ] Click TERMINAR after writing → text is saved, Tales replies with an acknowledgment, then the recommendation / promo renders.
- [ ] Click CANCELAR → textarea clears, returns to idle with CONTINUAR visible; ESCRIBIR is hidden.
- [ ] Skip writing (click CONTINUAR without pressing ESCRIBIR) → no acknowledgment, goes straight to recommendation.
- [ ] Verify chat bubbles, avatar, chips, and input all render correctly with the new `test-chat__*` classes.
- [ ] Check test titles display correctly on the test selection screen.