### PR TITLE
Feature: Connect onboarding tests

### DIFF
--- a/backend/src/onboarding/onboarding.controller.js
+++ b/backend/src/onboarding/onboarding.controller.js
@@ -17,7 +17,7 @@ const handlers = {
   [STATES.PQA_EVALUATION]: pqaEvaluationHandler,
   [STATES.RECOMMENDATION]: recommendationHandler,
   [STATES.EXIT]: async ({ session }) => ({
-    reply: "Ya tienes orientación para seguir. Usa los botones de arriba para ir a la teoría o al curso.",
+    reply: "Ya tienes orientación para seguir. Usa los botones de arriba para ir a la teoría o al test.",
     state: session.state,
   }),
 };

--- a/backend/src/onboarding/parsers/buildRecommendationReply.js
+++ b/backend/src/onboarding/parsers/buildRecommendationReply.js
@@ -4,7 +4,7 @@
  * @returns { string }
  */
 
-const CLOSING_PARAGRAPH = `Sea cual sea la recomendación, la decisión es tuya. Siempre te recomendarremos que leas la teoría primero para ganar contexto, pero si quieres ir directo al curso, adelante.
+const CLOSING_PARAGRAPH = `Sea cual sea la recomendación, la decisión es tuya. Siempre te recomendaremos que leas la teoría primero para ganar contexto, pero si quieres ir directo al test para entender mejor tus pensamientos estresantes actuales, adelante.
 
 Suerte en tu camino.`;
 
@@ -14,7 +14,7 @@ export function buildRecommendationReply(clarity) {
       return `
 Tu respuesta muestra un buen nivel de claridad y concreción.
 
-En este punto, te beneficiarás más de nuestro programa de práctica estructurada, donde trabajamos directamente con pensamientos como el que acabas de describir.
+En este punto, te beneficiarás más de hacer un test breve para entender mejor tus pensamientos estresantes actuales y observarlos con más precisión.
 
 ${CLOSING_PARAGRAPH}
 `;
@@ -22,7 +22,7 @@ ${CLOSING_PARAGRAPH}
       return `
 Tu respuesta tiene una claridad intermedia.
 
-Te recomendamos revisar nuestra teoría introductoria para afinar la forma de observar y formular tus pensamientos, y luego explorar el programa de práctica estructurada.
+Te recomendamos revisar nuestra teoría introductoria para afinar la forma de observar y formular tus pensamientos, y luego hacer el test para entender mejor tus pensamientos estresantes actuales.
 
 ${CLOSING_PARAGRAPH}
 `;
@@ -31,7 +31,7 @@ ${CLOSING_PARAGRAPH}
       return `
 Tu respuesta no demuestra demasiada claridad con respecto a tu potencial problema de pensamientos... Todavía.
 
-Antes de entrar en práctica intensiva, te recomendamos empezar por nuestra teoría introductoria, donde afinamos la forma de observar y formular tus pensamientos con mayor precisión.
+Antes de hacer el test, te recomendamos empezar por nuestra teoría introductoria, donde afinamos la forma de observar y formular tus pensamientos con mayor precisión.
 
 ${CLOSING_PARAGRAPH}
 `;

--- a/backend/src/onboarding/parsers/buildRecommendationReply.js
+++ b/backend/src/onboarding/parsers/buildRecommendationReply.js
@@ -22,7 +22,7 @@ ${CLOSING_PARAGRAPH}
       return `
 Tu respuesta tiene una claridad intermedia.
 
-Te recomendamos revisar nuestra teoría introductoria para afinar la forma de observar y formular tus pensamientos, y luego hacer el test para entender mejor tus pensamientos estresantes actuales.
+Te recomendamos revisar nuestra teoría introductoria para afinar la forma de observar y formular tus pensamientos, y luego hacer nuestro test para entender mejor tus pensamientos estresantes actuales.
 
 ${CLOSING_PARAGRAPH}
 `;
@@ -31,7 +31,7 @@ ${CLOSING_PARAGRAPH}
       return `
 Tu respuesta no demuestra demasiada claridad con respecto a tu potencial problema de pensamientos... Todavía.
 
-Antes de hacer el test, te recomendamos empezar por nuestra teoría introductoria, donde afinamos la forma de observar y formular tus pensamientos con mayor precisión.
+Antes de hacer nuestro test para entender mejor tus pensamientos estresantes actuales, te recomendamos empezar por nuestra teoría introductoria, donde afinamos la forma de observar y formular tus pensamientos con mayor precisión.
 
 ${CLOSING_PARAGRAPH}
 `;

--- a/frontend/src/Pages/Onboarding/Onboarding.jsx
+++ b/frontend/src/Pages/Onboarding/Onboarding.jsx
@@ -335,16 +335,16 @@ export default function Onboarding() {
               className="onboarding__exit-button"
               role="button"
               tabIndex={0}
-              onClick={() => navigate("/course")}
+              onClick={() => navigate("/test/stressing-thoughts-1")}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  navigate("/course");
+                  navigate("/test/stressing-thoughts-1");
                 }
               }}
             >
-              <img src="/icons/course.webp" alt="Curso" className="onboarding__exit-button__icon" />
-              <span className="onboarding__exit-button__label">CURSO</span>
+              <img src="/icons/course.webp" alt="Test" className="onboarding__exit-button__icon" />
+              <span className="onboarding__exit-button__label">TEST</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Updates the onboarding completion flow so users can choose between the theory and the thoughts test instead of theory and course. This directs users toward `/test/stressing-thoughts-1` to better understand their current stressing thoughts.

## Changes

### Onboarding exit CTA
- Changes the second onboarding exit option from `CURSO` to `TEST`.
- Updates click and keyboard navigation for the second option to route to `/test/stressing-thoughts-1`.
- Keeps the existing icon layout and asset for the second option.

### Tales onboarding copy
- Updates the final onboarding recommendation copy to describe the test as the next option instead of the course.
- Updates the onboarding `EXIT` fallback reply to reference theory or test.

## Notes
- The branch only changes onboarding exit behavior and related onboarding copy.

## Test plan
- [x] Complete onboarding manually and verify the exit buttons show `TEORÍA` and `TEST`.
- [x] Click `TEST` and verify it navigates to `/test/stressing-thoughts-1`.