### PR TITLE
Add: tests index page and navigation link

### DIFF
--- a/.cursor/docs/feature-workflow.md
+++ b/.cursor/docs/feature-workflow.md
@@ -41,3 +41,7 @@ Summarize:
 - what changed
 - remaining limitations
 - possible future improvements
+
+## 5. Provide commit description
+
+End the task by providing a recommended commit message reflecting the changes made.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import Instructions from './Pages/Instructions/Instructions.jsx';
 import PaymentSuccess from './Pages/Payment/PaymentSuccess.jsx';
 import PaymentCancel from './Pages/Payment/PaymentCancel.jsx';
 import PromoGate from './Pages/Promo/PromoGate.jsx';
+import Tests from './Pages/Tests/Tests.jsx';
 import ScrollToTop from './Components/ScrollToTop/ScrollToTop.jsx';
 
 function App() {
@@ -41,6 +42,7 @@ function App() {
                             <Route path='promo' element={<PromoGate />} />
                             <Route path='instructions' element={<Instructions />} />
                             <Route path='account' element={<Account />} />
+                            <Route path='tests' element={<Tests />} />
                             <Route path='test/:testId' element={<ThoughtsTest />} />
                             <Route path='session/:sessionId' element={<Session />} />
                         </Route>

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import './Navigation.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../Context/AuthContext.jsx';
@@ -10,49 +10,19 @@ const Navigation = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const { user, status } = useAuth();
-    const isCourseRoute = useMemo(
-        () => location.pathname.startsWith('/course') || location.pathname.startsWith('/session'),
-        [location.pathname],
-    );
-    const isArticleRoute = useMemo(() => location.pathname === '/', [location.pathname]);
-    const isInstructionsRoute = useMemo(
-        () => location.pathname.startsWith('/instructions'),
-        [location.pathname],
-    );
-    const isPromoRoute = useMemo(
-        () => location.pathname.startsWith('/promo'),
-        [location.pathname],
-    );
-
-    const goLogin = () => {
-        navigate('/login');
-        closeMenu();
-    };
-
-    const goCourse = () => {
-        navigate('/course');
-        closeMenu();
-    };
-
-    const goAccount = () => {
-        navigate('/account');
-        closeMenu();
-    };
-
-    const goInstructions = () => {
-        navigate('/instructions');
-        closeMenu();
-    };
-
-    const goArticle = () => {
-        navigate('/');
-        closeMenu();
-    };
-
-    const goPromo = () => {
-        navigate('/promo');
-        closeMenu();
-    };
+    const isCourseRoute = location.pathname.startsWith('/course') || location.pathname.startsWith('/session');
+    const isTestsRoute = location.pathname.startsWith('/tests') || location.pathname.startsWith('/test');
+    const isPromoRoute = location.pathname.startsWith('/promo');
+    const menuLinks = [
+        { label: 'TEORÍA', path: '/', isActive: location.pathname === '/' },
+        { label: 'CURSO', path: '/course', isActive: isCourseRoute },
+        { label: 'TESTS', path: '/tests', isActive: isTestsRoute },
+        {
+            label: 'INSTRUCCIONES',
+            path: '/instructions',
+            isActive: location.pathname.startsWith('/instructions'),
+        },
+    ];
 
     const openMenu = () => {
         setMenuState('open');
@@ -60,6 +30,11 @@ const Navigation = () => {
 
     const closeMenu = () => {
         setMenuState('closing');
+    };
+
+    const goTo = (path) => {
+        navigate(path);
+        closeMenu();
     };
 
     useEffect(() => {
@@ -104,11 +79,24 @@ const Navigation = () => {
                         </button>
                     </div>
                     <div className='navigation__menu-links'>
-                        <button type='button' className={`navigation__menu-link${isArticleRoute ? ' navigation__menu-link--active' : ''}`} onClick={goArticle}>TEORÍA</button>
-                        <button type='button' className={`navigation__menu-link${isCourseRoute ? ' navigation__menu-link--active' : ''}`} onClick={goCourse}>CURSO</button>
-                        <button type='button' className={`navigation__menu-link${isInstructionsRoute ? ' navigation__menu-link--active' : ''}`} onClick={goInstructions}>INSTRUCCIONES</button>
+                        {menuLinks.map((link) => (
+                            <button
+                                key={link.path}
+                                type='button'
+                                className={`navigation__menu-link${link.isActive ? ' navigation__menu-link--active' : ''}`}
+                                onClick={() => goTo(link.path)}
+                            >
+                                {link.label}
+                            </button>
+                        ))}
                         {isPromoEnabled() && (
-                            <button type='button' className={`navigation__menu-link navigation__menu-link--promo${isPromoRoute ? ' navigation__menu-link--active' : ''}`} onClick={goPromo}>GANA 25€</button>
+                            <button
+                                type='button'
+                                className={`navigation__menu-link navigation__menu-link--promo${isPromoRoute ? ' navigation__menu-link--active' : ''}`}
+                                onClick={() => goTo('/promo')}
+                            >
+                                GANA 25€
+                            </button>
                         )}
                     </div>
                 </div>
@@ -124,7 +112,11 @@ const Navigation = () => {
                 <button
                     type='button'
                     className={`navigation__section navigation__section--right${user ? ' navigation__section--right-user' : ''}`}
-                    onClick={user ? goAccount : (!user && status === 'ready' ? goLogin : undefined)}
+                    onClick={
+                        user
+                            ? () => goTo('/account')
+                            : (!user && status === 'ready' ? () => goTo('/login') : undefined)
+                    }
                 >
                     {user ? (
                         <>

--- a/frontend/src/Pages/Tests/Tests.css
+++ b/frontend/src/Pages/Tests/Tests.css
@@ -1,0 +1,74 @@
+.tests-page {
+  min-height: 100vh;
+  background: var(--background);
+  font-size: 18px;
+}
+
+.tests-page__content {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 30px 20px 120px;
+  box-sizing: border-box;
+}
+
+.tests-page__header {
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.tests-page__title {
+  margin: 0 0 10px;
+  font-size: 32px;
+  line-height: 1.12;
+  color: var(--accent);
+}
+
+.tests-page__subtitle {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.45;
+}
+
+.tests-page__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+
+.tests-page__button {
+  min-height: 58px;
+  border: 2px solid var(--accent);
+  border-radius: 16px;
+  padding: 14px 18px;
+  background: var(--accent);
+  color: var(--background);
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.tests-page__button:hover {
+  transform: translateY(-1px);
+}
+
+.tests-page__button:active {
+  transform: translateY(0);
+}
+
+.tests-page__button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  outline-offset: 3px;
+}
+
+@media (min-width: 1000px) {
+  .tests-page__content {
+    padding-top: 78px;
+  }
+
+  .tests-page__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/frontend/src/Pages/Tests/Tests.jsx
+++ b/frontend/src/Pages/Tests/Tests.jsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+import Navigation from '../../Components/Navigation/Navigation.jsx';
+import { thoughtsTests } from '../../data';
+import './Tests.css';
+
+const Tests = () => {
+  const navigate = useNavigate();
+  const tests = Object.values(thoughtsTests);
+
+  return (
+    <div className='tests-page'>
+      <Navigation />
+      <main className='tests-page__content'>
+        <header className='tests-page__header'>
+          <h1 className='tests-page__title'>Tests de pensamientos</h1>
+          <p className='tests-page__subtitle'>Aprende sobre tu mente</p>
+        </header>
+
+        <div className='tests-page__grid'>
+          {tests.map((test) => (
+            <button
+              key={test.id}
+              type='button'
+              className='tests-page__button'
+              onClick={() => navigate(`/test/${test.id}`)}
+            >
+              {test.title}
+            </button>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Tests;


### PR DESCRIPTION
## Summary

Adds a dedicated tests index page so users can browse available thought tests from a central `/tests` route. The navigation menu now includes a `TESTS` entry and marks both `/tests` and individual `/test/:testId` pages as active test routes.

## Changes

### Tests page
- Added a `/tests` route that renders all configured thought tests as selectable buttons.
- Added responsive styling for the tests index page, including accessible button focus states.

### Navigation
- Added `TESTS` to the main navigation menu.
- Updated active-route detection so `/tests` and `/test/:testId` are grouped under the tests section.

### Workflow docs
- Updated the feature workflow docs to include providing a commit description at the end of a task.

## Notes
- The page is driven by the existing `thoughtsTests` data, so newly added tests will appear automatically.

## Test plan
- [x] Open `/tests` and verify the page lists the available thought tests.
- [x] Click a test button and verify it navigates to the matching `/test/:testId` route.
- [x] Open the navigation menu and verify `TESTS` appears.
- [x] Verify `TESTS` is active on both `/tests` and individual test pages.
- [x] Verify the tests page layout works on mobile and desktop widths.