### PR TITLE
Feature: Journaling

### DIFF
--- a/backend/src/auth/auth.routes.js
+++ b/backend/src/auth/auth.routes.js
@@ -4,6 +4,10 @@ import {
   getSessionUnblocks,
   postSessionUnblock,
 } from '../sessionUnblocks/sessionUnblocks.controller.js';
+import {
+  getJournalEntries,
+  postJournalEntry,
+} from '../journalEntries/journalEntries.controller.js';
 import { requireAuth } from './auth.middleware.js';
 
 const router = express.Router();
@@ -13,6 +17,8 @@ router.get('/verify', verify);
 router.post('/logout', logout);
 router.get('/me/unblocked-sessions', requireAuth, getSessionUnblocks);
 router.post('/me/unblocked-sessions', requireAuth, postSessionUnblock);
+router.get('/me/journal-entries', requireAuth, getJournalEntries);
+router.post('/me/journal-entries', requireAuth, postJournalEntry);
 router.get('/me', requireAuth, me);
 
 export default router;

--- a/backend/src/db/README.md
+++ b/backend/src/db/README.md
@@ -155,6 +155,28 @@ Stores user cognitive entries (automatic thoughts) for CBT exercises.
 
 ---
 
+### 5b. `journal_entries`
+
+Stores free-form journal entries for the user diary (`/journal`). Separate from CBT `thoughts`.
+
+**Columns:**
+- `id` (UUID, PK): Unique entry identifier
+- `user_id` (UUID, FK → users.id): Author
+- `content` (TEXT): Journal text
+- `topics` (TEXT[]): Optional topic tags (default empty; UI later)
+- `created_at` (TIMESTAMP WITH TIME ZONE): When the entry was saved
+
+**Constraints:**
+- `user_id` references `users(id)` with CASCADE delete
+- `content` cannot be empty (trimmed length > 0)
+
+**Indexes:**
+- `idx_journal_entries_user_id`: User-scoped retrieval
+- `idx_journal_entries_created_at`: Chronological ordering (DESC)
+- `idx_journal_entries_topics`: GIN index for future topic filters
+
+---
+
 ### 6. `classifications`
 
 Stores cognitive distortion classifications for thoughts.
@@ -273,6 +295,12 @@ users (1) ──────< (N) magic_link_tokens
 ```sql
 -- Run after schema migration
 \i backend/src/db/migrations/002_seed_course_sessions.sql
+```
+
+### Journal Entries
+```sql
+-- Run after schema migration
+\i backend/src/db/migrations/003_journal_entries.sql
 ```
 
 ### Verify Migration Success

--- a/backend/src/db/migrations/003_journal_entries.sql
+++ b/backend/src/db/migrations/003_journal_entries.sql
@@ -1,0 +1,33 @@
+-- =====================================================
+-- Detox Mental Database Schema Migration
+-- Version: 003 - Journal Entries
+-- Description: Free-form journaling repository per user
+-- =====================================================
+
+-- =====================================================
+-- TABLE: journal_entries
+-- Purpose: Store user journal texts for later review
+-- =====================================================
+CREATE TABLE journal_entries (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    content TEXT NOT NULL,
+    topics TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_journal_entries_user_id
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT journal_entries_content_not_empty
+        CHECK (LENGTH(TRIM(content)) > 0)
+);
+
+CREATE INDEX idx_journal_entries_user_id ON journal_entries(user_id);
+CREATE INDEX idx_journal_entries_created_at ON journal_entries(created_at DESC);
+CREATE INDEX idx_journal_entries_topics ON journal_entries USING GIN (topics);
+
+-- =====================================================
+-- END OF MIGRATION
+-- =====================================================

--- a/backend/src/journalEntries/journalEntries.controller.js
+++ b/backend/src/journalEntries/journalEntries.controller.js
@@ -1,0 +1,31 @@
+import {
+  createJournalEntry,
+  listJournalEntriesForUser,
+} from './journalEntries.service.js';
+
+export const getJournalEntries = async (req, res) => {
+  try {
+    const entries = await listJournalEntriesForUser(req.user.id);
+    return res.status(200).json({ entries });
+  } catch (err) {
+    console.error('[journal-entries GET]', err);
+    return res.status(500).json({ message: 'Error al cargar el diario.' });
+  }
+};
+
+export const postJournalEntry = async (req, res) => {
+  const raw = req.body?.content;
+  const content = typeof raw === 'string' ? raw.trim() : '';
+
+  if (!content) {
+    return res.status(400).json({ message: 'El texto del diario no puede estar vacío.' });
+  }
+
+  try {
+    const entry = await createJournalEntry(req.user.id, content);
+    return res.status(201).json({ entry });
+  } catch (err) {
+    console.error('[journal-entries POST]', err);
+    return res.status(500).json({ message: 'No se pudo guardar la entrada.' });
+  }
+};

--- a/backend/src/journalEntries/journalEntries.service.js
+++ b/backend/src/journalEntries/journalEntries.service.js
@@ -1,0 +1,29 @@
+import pool from '../db/db.js';
+
+const mapRow = (row) => ({
+  id: row.id,
+  content: row.content,
+  topics: row.topics ?? [],
+  createdAt: row.created_at,
+});
+
+export const createJournalEntry = async (userId, content) => {
+  const { rows } = await pool.query(
+    `INSERT INTO journal_entries (user_id, content)
+     VALUES ($1, $2)
+     RETURNING id, content, topics, created_at`,
+    [userId, content],
+  );
+  return mapRow(rows[0]);
+};
+
+export const listJournalEntriesForUser = async (userId) => {
+  const { rows } = await pool.query(
+    `SELECT id, content, topics, created_at
+     FROM journal_entries
+     WHERE user_id = $1
+     ORDER BY created_at DESC`,
+    [userId],
+  );
+  return rows.map(mapRow);
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,8 @@ import PaymentSuccess from './Pages/Payment/PaymentSuccess.jsx';
 import PaymentCancel from './Pages/Payment/PaymentCancel.jsx';
 import PromoGate from './Pages/Promo/PromoGate.jsx';
 import Tests from './Pages/Tests/Tests.jsx';
+import Journal from './Pages/Journal/Journal.jsx';
+import JournalHistory from './Pages/Journal/JournalHistory.jsx';
 import ScrollToTop from './Components/ScrollToTop/ScrollToTop.jsx';
 
 function App() {
@@ -44,6 +46,8 @@ function App() {
                             <Route path='account' element={<Account />} />
                             <Route path='tests' element={<Tests />} />
                             <Route path='test/:testId' element={<ThoughtsTest />} />
+                            <Route path='journal/history' element={<JournalHistory />} />
+                            <Route path='journal' element={<Journal />} />
                             <Route path='session/:sessionId' element={<Session />} />
                         </Route>
                     </Routes>

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -12,11 +12,13 @@ const Navigation = () => {
     const { user, status } = useAuth();
     const isCourseRoute = location.pathname.startsWith('/course') || location.pathname.startsWith('/session');
     const isTestsRoute = location.pathname.startsWith('/tests') || location.pathname.startsWith('/test');
+    const isJournalRoute = location.pathname.startsWith('/journal');
     const isPromoRoute = location.pathname.startsWith('/promo');
     const menuLinks = [
         { label: 'TEORÍA', path: '/', isActive: location.pathname === '/' },
         { label: 'CURSO', path: '/course', isActive: isCourseRoute },
         { label: 'TESTS', path: '/tests', isActive: isTestsRoute },
+        { label: 'DIARIO', path: '/journal', isActive: isJournalRoute },
         {
             label: 'INSTRUCCIONES',
             path: '/instructions',

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -1,0 +1,212 @@
+.journal-page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
+  color: var(--text);
+}
+
+.journal-page__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: min(100%, 640px);
+  margin: 0 auto;
+  padding: 96px 20px 120px;
+  box-sizing: border-box;
+}
+
+.journal-page__main--history {
+  justify-content: flex-start;
+  gap: 24px;
+}
+
+.journal-page__prompt {
+  margin: 0;
+  padding-top: 12vh;
+  text-align: center;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--primary);
+}
+
+.journal-page__composer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.journal-page__textarea {
+  width: 100%;
+  min-height: 160px;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  font: inherit;
+  line-height: 1.5;
+  color: inherit;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 12px;
+  background: var(--surface, #fff);
+  resize: none;
+  overflow: hidden;
+}
+
+.journal-page__textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.journal-page__textarea:disabled {
+  opacity: 0.7;
+}
+
+.journal-page__complete-button {
+  width: 100%;
+  margin-top: 0;
+  background: var(--accent);
+  border: 2px solid var(--accent);
+  color: var(--background);
+}
+
+.journal-page__complete-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.journal-page__history-link {
+  display: block;
+  text-align: center;
+  color: var(--accent);
+  text-decoration: underline;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.journal-guest-modal {
+  position: fixed;
+  width: 80%;
+  margin: auto;
+  background-color: white;
+  border-radius: 16px;
+  padding: 40px 8%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  box-sizing: border-box;
+}
+
+.journal-guest-modal__title {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  color: var(--primary);
+}
+
+.journal-guest-modal__text {
+  text-align: left;
+  margin: 0 0 1.25rem;
+  line-height: 1.5;
+}
+
+.journal-guest-modal__button {
+  width: 100%;
+  padding: 12px 0;
+  margin-bottom: 0.75rem;
+  background: var(--accent);
+  border: 2px solid var(--accent);
+  color: var(--background);
+}
+
+.journal-guest-modal__button--secondary {
+  background: var(--background);
+  color: var(--accent);
+}
+
+.journal-guest-modal__close-text {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: center;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: underline;
+  color: inherit;
+  cursor: pointer;
+}
+
+.journal-history__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.journal-history__title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.journal-history__back-link,
+.journal-history__action-link {
+  color: var(--accent);
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.journal-history__status,
+.journal-history__empty {
+  margin: 0;
+  text-align: center;
+  color: var(--muted, #6b7280);
+  line-height: 1.5;
+}
+
+.journal-history__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding-top: 48px;
+}
+
+.journal-history__feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.journal-history__card {
+  padding: 16px 18px;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 12px;
+  background: var(--surface, #fff);
+}
+
+.journal-history__date {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.journal-history__excerpt {
+  margin: 0;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+@media (min-width: 1000px) {
+  .journal-guest-modal {
+    max-width: 500px;
+    padding: 40px;
+  }
+}

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -204,6 +204,32 @@
   white-space: pre-wrap;
 }
 
+.journal-history__excerpt--toggleable {
+  cursor: pointer;
+}
+
+.journal-history__excerpt--toggleable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.journal-history__toggle {
+  display: block;
+  width: auto;
+  margin: 10px 0 0 auto;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: underline;
+  text-align: right;
+  cursor: pointer;
+}
+
 @media (min-width: 1000px) {
   .journal-guest-modal {
     max-width: 500px;

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -1,0 +1,156 @@
+import { useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Navigation from '../../Components/Navigation/Navigation.jsx';
+import CloseIcon from '../../Components/CloseIcon/CloseIcon.jsx';
+import { useAuth } from '../../Context/AuthContext.jsx';
+import { apiFetch } from '../../api/client.js';
+import { emitToast } from '../../lib/toastBus.js';
+import './Journal.css';
+
+const Journal = () => {
+  const navigate = useNavigate();
+  const { user, status } = useAuth();
+  const textareaRef = useRef(null);
+  const [text, setText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [showGuestModal, setShowGuestModal] = useState(false);
+
+  const handleTextChange = (e) => {
+    setText(e.target.value);
+    const el = e.target;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
+
+  const clearComposer = () => {
+    setText('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  };
+
+  const saveEntry = async () => {
+    const content = text.trim();
+    if (!content || saving) return;
+
+    setSaving(true);
+    try {
+      const res = await apiFetch('/auth/me/journal-entries', {
+        method: 'POST',
+        body: { content },
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || 'No se pudo guardar la entrada.');
+      }
+      clearComposer();
+      emitToast('Entrada guardada en tu diario.');
+    } catch (err) {
+      console.error('[journal POST]', err);
+      emitToast(err.message || 'No se pudo guardar la entrada.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleComplete = () => {
+    if (!text.trim() || saving || status === 'loading') return;
+
+    if (!user) {
+      setShowGuestModal(true);
+      return;
+    }
+
+    saveEntry();
+  };
+
+  const handleGuestDiscard = () => {
+    clearComposer();
+    setShowGuestModal(false);
+  };
+
+  const handleGuestLogin = () => {
+    setShowGuestModal(false);
+    navigate('/login');
+  };
+
+  return (
+    <div className="journal-page">
+      <Navigation />
+      <main className="journal-page__main">
+        <h1 className="journal-page__prompt">¿Qué tienes en mente?</h1>
+
+        <div className="journal-page__composer">
+          <textarea
+            ref={textareaRef}
+            className="journal-page__textarea"
+            value={text}
+            onChange={handleTextChange}
+            placeholder="Escribe aquí..."
+            aria-label="Texto del diario"
+            disabled={saving}
+          />
+          <button
+            type="button"
+            className="journal-page__complete-button"
+            onClick={handleComplete}
+            disabled={!text.trim() || saving || status === 'loading'}
+          >
+            {saving ? 'GUARDANDO...' : 'COMPLETAR'}
+          </button>
+          <Link to="/journal/history" className="journal-page__history-link">
+            Ver historial
+          </Link>
+        </div>
+      </main>
+
+      {showGuestModal && (
+        <div
+          className="modal-overlay"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowGuestModal(false);
+          }}
+        >
+          <div
+            className="journal-guest-modal modal-fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="journal-guest-modal-title"
+          >
+            <CloseIcon handleCloseModal={() => setShowGuestModal(false)} />
+            <h2 id="journal-guest-modal-title" className="journal-guest-modal__title">
+              Esta entrada no se guardará
+            </h2>
+            <p className="journal-guest-modal__text">
+              No has iniciado sesión. Si continúas, el texto se perderá al completar.
+              Inicia sesión para guardarlo en tu diario.
+            </p>
+            <button
+              type="button"
+              className="journal-guest-modal__button"
+              onClick={handleGuestLogin}
+            >
+              INICIAR SESIÓN
+            </button>
+            <button
+              type="button"
+              className="journal-guest-modal__button journal-guest-modal__button--secondary"
+              onClick={handleGuestDiscard}
+            >
+              CONTINUAR SIN GUARDAR
+            </button>
+            <button
+              type="button"
+              className="journal-guest-modal__close-text"
+              onClick={() => setShowGuestModal(false)}
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Journal;

--- a/frontend/src/Pages/Journal/JournalHistory.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.jsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Navigation from '../../Components/Navigation/Navigation.jsx';
+import { useAuth } from '../../Context/AuthContext.jsx';
+import { apiFetch } from '../../api/client.js';
+import { emitToast } from '../../lib/toastBus.js';
+import './Journal.css';
+
+const EXCERPT_WORD_COUNT = 40;
+
+const formatEntryDate = (iso) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'Fecha desconocida';
+  return new Intl.DateTimeFormat('es-ES', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(date);
+};
+
+const getExcerpt = (content) => {
+  const words = String(content).trim().split(/\s+/).filter(Boolean);
+  if (words.length <= EXCERPT_WORD_COUNT) return words.join(' ');
+  return `${words.slice(0, EXCERPT_WORD_COUNT).join(' ')}…`;
+};
+
+const JournalHistory = () => {
+  const { user, status } = useAuth();
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (status !== 'ready' || !user) {
+      setEntries([]);
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const loadEntries = async () => {
+      setLoading(true);
+      try {
+        const res = await apiFetch('/auth/me/journal-entries');
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.message || 'No se pudo cargar el diario.');
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          setEntries(Array.isArray(data.entries) ? data.entries : []);
+        }
+      } catch (err) {
+        console.error('[journal GET]', err);
+        if (!cancelled) {
+          setEntries([]);
+          emitToast(err.message || 'No se pudo cargar el diario.');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    loadEntries();
+    return () => {
+      cancelled = true;
+    };
+  }, [status, user]);
+
+  return (
+    <div className="journal-page journal-page--history">
+      <Navigation />
+      <main className="journal-page__main journal-page__main--history">
+        <header className="journal-history__header">
+          <h1 className="journal-history__title">Historial</h1>
+          <Link to="/journal" className="journal-history__back-link">
+            Escribir
+          </Link>
+        </header>
+
+        {status === 'loading' && (
+          <p className="journal-history__status">Cargando…</p>
+        )}
+
+        {status === 'ready' && !user && (
+          <div className="journal-history__empty">
+            <p>Inicia sesión para ver las entradas guardadas en tu diario.</p>
+            <Link to="/login" className="journal-history__action-link">
+              Iniciar sesión
+            </Link>
+          </div>
+        )}
+
+        {status === 'ready' && user && loading && (
+          <p className="journal-history__status">Cargando entradas…</p>
+        )}
+
+        {status === 'ready' && user && !loading && entries.length === 0 && (
+          <div className="journal-history__empty">
+            <p>Aún no hay entradas en tu diario.</p>
+            <Link to="/journal" className="journal-history__action-link">
+              Escribir la primera
+            </Link>
+          </div>
+        )}
+
+        {status === 'ready' && user && !loading && entries.length > 0 && (
+          <ul className="journal-history__feed">
+            {entries.map((entry) => (
+              <li key={entry.id} className="journal-history__card">
+                <time
+                  className="journal-history__date"
+                  dateTime={entry.createdAt}
+                >
+                  {formatEntryDate(entry.createdAt)}
+                </time>
+                <p className="journal-history__excerpt">{getExcerpt(entry.content)}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default JournalHistory;

--- a/frontend/src/Pages/Journal/JournalHistory.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.jsx
@@ -18,6 +18,9 @@ const formatEntryDate = (iso) => {
   }).format(date);
 };
 
+const getWordCount = (content) =>
+  String(content).trim().split(/\s+/).filter(Boolean).length;
+
 const getExcerpt = (content) => {
   const words = String(content).trim().split(/\s+/).filter(Boolean);
   if (words.length <= EXCERPT_WORD_COUNT) return words.join(' ');
@@ -28,10 +31,12 @@ const JournalHistory = () => {
   const { user, status } = useAuth();
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [expandedIds, setExpandedIds] = useState(() => new Set());
 
   useEffect(() => {
     if (status !== 'ready' || !user) {
       setEntries([]);
+      setExpandedIds(new Set());
       setLoading(false);
       return undefined;
     }
@@ -49,11 +54,13 @@ const JournalHistory = () => {
         const data = await res.json();
         if (!cancelled) {
           setEntries(Array.isArray(data.entries) ? data.entries : []);
+          setExpandedIds(new Set());
         }
       } catch (err) {
         console.error('[journal GET]', err);
         if (!cancelled) {
           setEntries([]);
+          setExpandedIds(new Set());
           emitToast(err.message || 'No se pudo cargar el diario.');
         }
       } finally {
@@ -66,6 +73,15 @@ const JournalHistory = () => {
       cancelled = true;
     };
   }, [status, user]);
+
+  const toggleExpanded = (entryId) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(entryId)) next.delete(entryId);
+      else next.add(entryId);
+      return next;
+    });
+  };
 
   return (
     <div className="journal-page journal-page--history">
@@ -106,17 +122,54 @@ const JournalHistory = () => {
 
         {status === 'ready' && user && !loading && entries.length > 0 && (
           <ul className="journal-history__feed">
-            {entries.map((entry) => (
-              <li key={entry.id} className="journal-history__card">
-                <time
-                  className="journal-history__date"
-                  dateTime={entry.createdAt}
-                >
-                  {formatEntryDate(entry.createdAt)}
-                </time>
-                <p className="journal-history__excerpt">{getExcerpt(entry.content)}</p>
-              </li>
-            ))}
+            {entries.map((entry) => {
+              const expandable = getWordCount(entry.content) > EXCERPT_WORD_COUNT;
+              const expanded = expandedIds.has(entry.id);
+              const bodyText =
+                expandable && !expanded
+                  ? getExcerpt(entry.content)
+                  : entry.content;
+
+              return (
+                <li key={entry.id} className="journal-history__card">
+                  <time
+                    className="journal-history__date"
+                    dateTime={entry.createdAt}
+                  >
+                    {formatEntryDate(entry.createdAt)}
+                  </time>
+                  {expandable ? (
+                    <p
+                      className="journal-history__excerpt journal-history__excerpt--toggleable"
+                      onClick={() => toggleExpanded(entry.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          toggleExpanded(entry.id);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={expanded}
+                    >
+                      {bodyText}
+                    </p>
+                  ) : (
+                    <p className="journal-history__excerpt">{bodyText}</p>
+                  )}
+                  {expandable && (
+                    <button
+                      type="button"
+                      className="journal-history__toggle"
+                      onClick={() => toggleExpanded(entry.id)}
+                      aria-expanded={expanded}
+                    >
+                      {expanded ? 'Mostrar menos' : 'Mostrar más'}
+                    </button>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </main>


### PR DESCRIPTION
## Summary

Adds a free-form journaling feature ("Diario"): a new page where signed-in users can write and save journal entries, plus a history feed to review and expand past entries.

## Changes

### Backend
- Added `journal_entries` table (migration `003_journal_entries.sql`) with `user_id`, `content`, `topics` (reserved for future tagging), and `created_at`, cascading on user deletion and enforcing non-empty content.
- Added `journalEntries.service.js` and `journalEntries.controller.js` to create and list entries scoped to the authenticated user.
- Registered `GET /auth/me/journal-entries` and `POST /auth/me/journal-entries` routes behind `requireAuth`.
- Documented the new table in `backend/src/db/README.md`.

### Frontend
- Added `Journal` page (`/journal`) with an auto-growing textarea and a "COMPLETAR" button that saves the entry via the API.
- Guests (not logged in) get a confirmation modal warning that unsaved text will be lost unless they log in, instead of a silent failed save.
- Added `JournalHistory` page (`/journal/history`) that lists saved entries newest-first, showing a formatted date and a truncated excerpt (40 words) that can be expanded/collapsed in place (click or keyboard-activated).
- Wired up routing in `App.jsx` and added a "DIARIO" entry to the main `Navigation` component.

## Notes
- `topics` column is unused for now (defaults to empty array) — intended for future topic tagging/filtering, backed by a GIN index already in place.
- No automated tests were added for the new pages/endpoints.

## Test plan
- [x] As a guest, go to `/journal`, type text, and click COMPLETAR — verify the guest modal appears and choosing "CONTINUAR SIN GUARDAR" clears the composer while "INICIAR SESIÓN" navigates to `/login`.
- [x] Log in, write an entry, and save it — verify a success toast appears and the composer clears.
- [x] Visit `/journal/history` — verify the new entry appears at the top with the correct date.
- [x] Save an entry longer than 40 words — verify it truncates with "Mostrar más" and expands/collapses correctly via click and keyboard (Enter/Space).
- [ ] Visit `/journal/history` as a guest — verify the "Inicia sesión" prompt is shown instead of entries.
- [x] Confirm the "DIARIO" nav link highlights as active on both `/journal` and `/journal/history`.