### PR TITLE
Chore: Interface polishing

### DIFF
--- a/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.css
+++ b/frontend/src/Components/BlockedSessionModal/BlockedSessionModal.css
@@ -1,5 +1,5 @@
 .blocked-session-modal {
-    position: fixed;
+    position: relative;
     width: 80%;
     margin: auto;
     background-color: white;

--- a/frontend/src/Components/EnterCodeModal/EnterCodeModal.css
+++ b/frontend/src/Components/EnterCodeModal/EnterCodeModal.css
@@ -1,5 +1,5 @@
 .enter-code-modal {
-    position: fixed;
+    position: relative;
     width: 80%;
     z-index: 3;
     background-color: white;

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -52,12 +52,13 @@ const Navigation = () => {
         let lastY = window.scrollY;
         const onScroll = () => {
             const currentY = window.scrollY;
-            if (currentY < lastY) {
+            if (currentY < lastY - 200) {
                 setIsBarVisible(true);
+                lastY = currentY;
             } else if (currentY > lastY + 6) {
                 setIsBarVisible(false);
+                lastY = currentY;
             }
-            lastY = currentY;
         };
         window.addEventListener('scroll', onScroll, { passive: true });
         return () => window.removeEventListener('scroll', onScroll);

--- a/frontend/src/Components/RewardOfferModal/RewardOfferModal.css
+++ b/frontend/src/Components/RewardOfferModal/RewardOfferModal.css
@@ -2,7 +2,8 @@
   position: relative;
   width: min(560px, calc(100vw - 32px));
   max-height: 90vh;
-  margin-top: -50px;
+  max-height: 90dvh;
+  margin: auto;
   padding: 28px 20px 24px;
   border-radius: 24px;
   background: var(--background);

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -20,6 +20,10 @@ const Journal = () => {
     const el = e.target;
     el.style.height = 'auto';
     el.style.height = `${el.scrollHeight}px`;
+    // Keep the growing composer (textarea end + actions) pinned in view.
+    requestAnimationFrame(() => {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+    });
   };
 
   const clearComposer = () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,14 +120,14 @@ code {
 .modal-overlay,
 .animation-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100svh;
+  inset: 0;
   z-index: 2;
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
+    env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  overflow-y: auto;
   background-color: rgba(0,0,0,0.25);
 }
 


### PR DESCRIPTION
## Summary

Polishes a few mobile interface rough edges: the bottom nav is less twitchy on small scroll nudges, the Journal composer stays pinned to the writing surface as text grows, and course modals fully cover and center on the phone viewport.

## Changes

### Navigation
- Require ~200px of upward scroll before showing the bar again, and only update the scroll anchor when show/hide thresholds are crossed so tiny chat/`scrollIntoView` movements no longer flash the nav open.

### Journal
- After auto-resizing the textarea, scroll to the page bottom so the end of the entry plus **COMPLETAR** and **Ver historial** stay in view while typing longer texts.

### Modals (Blocked Session / Reward Offer)
- Make the shared modal overlay use `inset: 0` (instead of `100svh`) so the dimmed backdrop covers the full mobile screen, including when browser chrome collapses.
- Center blocked-session and enter-code modals via `position: relative` inside the flex overlay; remove the reward modal’s upward offset so it sits in the middle of the screen.

## Notes
- Enter Code modal positioning was updated as part of the blocked-session flow.
- Journal auto-scroll runs on every keystroke once the composer is taller than the viewport, including mid-text edits.

## Test plan
- [ ] On a long page / chat flow: small upward nudges do not show the nav; a clear upward scroll (~200px) does; scrolling down still hides it quickly.
- [ ] On Journal: type a long entry and confirm the textarea bottom, **COMPLETAR**, and **Ver historial** stay visible without manual scrolling.
- [ ] On Course (mobile): open Blocked Session and Reward Offer modals — overlay covers the full screen with no bright gap at the bottom, and each modal is vertically centered.
- [ ] From Blocked Session, open Enter Code and confirm it is also centered over a full overlay.