### PR TITLE
Fixing with Claude what Grok broke

### DIFF
--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -42,6 +42,7 @@
 .journal-page__textarea {
   width: 100%;
   min-height: 160px;
+  max-height: 240px;
   box-sizing: border-box;
   padding: 12px 14px;
   font: inherit;
@@ -51,7 +52,7 @@
   border-radius: 12px;
   background: var(--surface, #fff);
   resize: none;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .journal-page__textarea:focus {

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -20,10 +20,6 @@ const Journal = () => {
     const el = e.target;
     el.style.height = 'auto';
     el.style.height = `${el.scrollHeight}px`;
-    // Keep the growing composer (textarea end + actions) pinned in view.
-    requestAnimationFrame(() => {
-      window.scrollTo(0, document.documentElement.scrollHeight);
-    });
   };
 
   const clearComposer = () => {


### PR DESCRIPTION
Fix Journal textarea jumping and whitespace on mobile.

Remove per-keystroke window scrolling and cap the textarea with internal scroll so the caret and action buttons stay visible without fighting the mobile keyboard viewport.