### PR TITLE
fix(journal): blank lines become paragraph breaks in OCR prompt

### DIFF
--- a/backend/src/journalTranscription/buildTranscriptionMessages.js
+++ b/backend/src/journalTranscription/buildTranscriptionMessages.js
@@ -1,6 +1,9 @@
 export const TRANSCRIPTION_PROMPT = `Transcribe the handwritten text in this image exactly as it is written.
 The text may be in Spanish or English: transcribe it verbatim in its original language and do not translate it.
-Preserve the original line breaks and paragraphs.
+Treat consecutive handwritten lines as a continuous paragraph: join them with spaces and do not insert a line break where the writer simply ran out of space.
+If a word is hyphenated across lines (e.g. "bed-" on one line and "room" on the next), join them into a single word without the hyphen or a line break (e.g. "bedroom").
+Only insert a paragraph break when there is a clearly blank line between blocks of text. Represent each intentional paragraph break as a double line break (\\n\\n).
+Do not preserve soft wrapping within a paragraph.
 Do not summarize, correct spelling, rephrase, or add any commentary.
 If a word or section is illegible, write [ilegible] in its place.
 Respond only with the transcribed text.`;

--- a/backend/src/journalTranscription/buildTranscriptionMessages.test.js
+++ b/backend/src/journalTranscription/buildTranscriptionMessages.test.js
@@ -34,3 +34,11 @@ test('prompt instructs verbatim, bilingual, non-translating transcription', () =
   assert.match(TRANSCRIPTION_PROMPT, /do not translate/i);
   assert.match(TRANSCRIPTION_PROMPT, /\[ilegible\]/);
 });
+
+test('prompt joins soft wraps and uses double line breaks for paragraphs', () => {
+  assert.match(TRANSCRIPTION_PROMPT, /continuous paragraph/i);
+  assert.match(TRANSCRIPTION_PROMPT, /hyphenated across lines/i);
+  assert.match(TRANSCRIPTION_PROMPT, /double line break/i);
+  assert.match(TRANSCRIPTION_PROMPT, /\\n\\n/);
+  assert.doesNotMatch(TRANSCRIPTION_PROMPT, /Preserve the original line breaks/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the journal handwriting transcription prompt so the vision model no longer preserves soft visual line wraps.

- Join consecutive handwritten lines into continuous paragraphs
- Rejoin hyphenated wrap breaks (e.g. `bed-` / `room` → `bedroom`)
- Emit `\n\n` only when there is a clearly blank line (intentional paragraph break)

## Test plan
- [x] Unit tests for prompt wording (`buildTranscriptionMessages.test.js`)
- [ ] Smoke-test transcription with a page that wraps mid-word with a hyphen
- [ ] Smoke-test transcription with an intentional blank line between paragraphs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8bf-3630-7b24-9844-e568f339b0ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8bf-3630-7b24-9844-e568f339b0ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

