### PR TITLE
Feature: journal topics

### DIFF
--- a/backend/src/journalEntries/journalEntries.controller.js
+++ b/backend/src/journalEntries/journalEntries.controller.js
@@ -3,6 +3,46 @@ import {
   listJournalEntriesForUser,
 } from './journalEntries.service.js';
 
+export const ALLOWED_JOURNAL_TOPICS = [
+  'Trabajo',
+  'Interpersonal',
+  'Reflexión',
+  'Sabiduría',
+  'Preocupaciones',
+];
+
+const MAX_TOPICS = 3;
+
+const parseTopics = (raw) => {
+  if (raw === undefined || raw === null) {
+    return { ok: true, topics: [] };
+  }
+
+  if (!Array.isArray(raw)) {
+    return { ok: false, message: 'Los temas deben enviarse como una lista.' };
+  }
+
+  if (raw.length > MAX_TOPICS) {
+    return {
+      ok: false,
+      message: `Puedes seleccionar hasta ${MAX_TOPICS} temas por entrada.`,
+    };
+  }
+
+  const topics = [];
+  for (const item of raw) {
+    if (typeof item !== 'string' || !ALLOWED_JOURNAL_TOPICS.includes(item)) {
+      return { ok: false, message: 'Uno o más temas no son válidos.' };
+    }
+    if (topics.includes(item)) {
+      return { ok: false, message: 'No puedes repetir el mismo tema.' };
+    }
+    topics.push(item);
+  }
+
+  return { ok: true, topics };
+};
+
 export const getJournalEntries = async (req, res) => {
   try {
     const entries = await listJournalEntriesForUser(req.user.id);
@@ -21,8 +61,13 @@ export const postJournalEntry = async (req, res) => {
     return res.status(400).json({ message: 'El texto del diario no puede estar vacío.' });
   }
 
+  const parsedTopics = parseTopics(req.body?.topics);
+  if (!parsedTopics.ok) {
+    return res.status(400).json({ message: parsedTopics.message });
+  }
+
   try {
-    const entry = await createJournalEntry(req.user.id, content);
+    const entry = await createJournalEntry(req.user.id, content, parsedTopics.topics);
     return res.status(201).json({ entry });
   } catch (err) {
     console.error('[journal-entries POST]', err);

--- a/backend/src/journalEntries/journalEntries.service.js
+++ b/backend/src/journalEntries/journalEntries.service.js
@@ -7,12 +7,12 @@ const mapRow = (row) => ({
   createdAt: row.created_at,
 });
 
-export const createJournalEntry = async (userId, content) => {
+export const createJournalEntry = async (userId, content, topics = []) => {
   const { rows } = await pool.query(
-    `INSERT INTO journal_entries (user_id, content)
-     VALUES ($1, $2)
+    `INSERT INTO journal_entries (user_id, content, topics)
+     VALUES ($1, $2, $3)
      RETURNING id, content, topics, created_at`,
-    [userId, content],
+    [userId, content, topics],
   );
   return mapRow(rows[0]);
 };

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -43,11 +43,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  justify-content: center;
+  justify-content: left;
   width: 100%;
 }
 
 .journal-page__topic-chip {
+  width: auto;
+  flex: 0 0 auto;
   padding: 8px 14px;
   border: 1.5px solid var(--accent);
   border-radius: 999px;

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -39,6 +39,61 @@
   gap: 12px;
 }
 
+.journal-page__topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  width: 100%;
+}
+
+.journal-page__topic-chip {
+  padding: 8px 14px;
+  border: 1.5px solid var(--accent);
+  border-radius: 999px;
+  background: var(--surface, #fff);
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.journal-page__topic-chip:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 8%, #fff);
+}
+
+.journal-page__topic-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.journal-page__topic-chip--selected {
+  background: var(--accent);
+  color: var(--background);
+}
+
+.journal-page__topic-chip--selected:hover:not(:disabled) {
+  background: var(--accent);
+}
+
+.journal-page__topic-chip:disabled {
+  border-color: var(--border, #d1d5db);
+  background: #ececec;
+  color: var(--muted, #6b7280);
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.journal-page__topic-chip--selected:disabled {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--background);
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
 .journal-page__textarea {
   width: 100%;
   min-height: 160px;
@@ -294,10 +349,29 @@
 
 .journal-history__date {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
   font-size: 13px;
   font-weight: 600;
   color: var(--accent);
+}
+
+.journal-history__topics {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.journal-history__topic-chip {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--background);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .journal-history__excerpt {

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -12,12 +12,23 @@ import {
 } from './journalImage.js';
 import './Journal.css';
 
+const JOURNAL_TOPICS = [
+  'Trabajo',
+  'Interpersonal',
+  'Reflexión',
+  'Sabiduría',
+  'Preocupaciones',
+];
+
+const MAX_SELECTED_TOPICS = 3;
+
 const Journal = () => {
   const navigate = useNavigate();
   const { user, status } = useAuth();
   const textareaRef = useRef(null);
   const fileInputRef = useRef(null);
   const [text, setText] = useState('');
+  const [selectedTopics, setSelectedTopics] = useState([]);
   const [saving, setSaving] = useState(false);
   const [showGuestModal, setShowGuestModal] = useState(false);
   const [imageFile, setImageFile] = useState(null);
@@ -26,6 +37,7 @@ const Journal = () => {
 
   const canUseImages = status === 'ready' && !!user;
   const busy = saving || transcribing;
+  const topicLimitReached = selectedTopics.length >= MAX_SELECTED_TOPICS;
 
   const resizeTextarea = () => {
     const el = textareaRef.current;
@@ -48,6 +60,17 @@ const Journal = () => {
 
   const clearComposer = () => {
     setText('');
+    setSelectedTopics([]);
+  };
+
+  const toggleTopic = (topic) => {
+    setSelectedTopics((prev) => {
+      if (prev.includes(topic)) {
+        return prev.filter((item) => item !== topic);
+      }
+      if (prev.length >= MAX_SELECTED_TOPICS) return prev;
+      return [...prev, topic];
+    });
   };
 
   const clearImage = () => {
@@ -116,7 +139,7 @@ const Journal = () => {
     try {
       const res = await apiFetch('/auth/me/journal-entries', {
         method: 'POST',
-        body: { content },
+        body: { content, topics: selectedTopics },
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -160,6 +183,29 @@ const Journal = () => {
         <h1 className="journal-page__prompt">¿Qué tienes en mente?</h1>
 
         <div className="journal-page__composer">
+          <div
+            className="journal-page__topics"
+            role="group"
+            aria-label="Temas del diario"
+          >
+            {JOURNAL_TOPICS.map((topic) => {
+              const selected = selectedTopics.includes(topic);
+              const disabled = busy || (!selected && topicLimitReached);
+              return (
+                <button
+                  key={topic}
+                  type="button"
+                  className={`journal-page__topic-chip${selected ? ' journal-page__topic-chip--selected' : ''}`}
+                  onClick={() => toggleTopic(topic)}
+                  disabled={disabled}
+                  aria-pressed={selected}
+                >
+                  {topic}
+                </button>
+              );
+            })}
+          </div>
+
           <textarea
             ref={textareaRef}
             className="journal-page__textarea"

--- a/frontend/src/Pages/Journal/JournalHistory.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.jsx
@@ -141,6 +141,18 @@ const JournalHistory = () => {
                   >
                     {formatEntryDate(entry.createdAt)}
                   </time>
+                  {Array.isArray(entry.topics) && entry.topics.length > 0 && (
+                    <ul
+                      className="journal-history__topics"
+                      aria-label="Temas"
+                    >
+                      {entry.topics.map((topic) => (
+                        <li key={topic} className="journal-history__topic-chip">
+                          {topic}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                   {expandable ? (
                     <p
                       className="journal-history__excerpt journal-history__excerpt--toggleable"


### PR DESCRIPTION
## Summary

Adds optional topic classification to journal entries so writers can tag each entry with up to three fixed themes, persist them on create, and see them again in history.

## Changes

### Backend
- Accepts a `topics` array on `POST /auth/me/journal-entries`, validates against a fixed allowlist (max 3, no duplicates), and stores it in the existing `topics` column.
- List responses already included `topics`; create now persists and returns the selected values.

### Journal composer
- Adds five topic chips above the text area: Trabajo, Interpersonal, Reflexión, Sabiduría, Preocupaciones.
- Chips toggle on/off; at three selected, remaining chips are disabled; selection clears after save or discard.
- Submits `{ content, topics }` with the entry.

### Journal history
- Renders each entry’s topics between the date and body, with spacing adjusted so chips fit comfortably.
- Entries without topics keep the previous layout.

## Notes
- Topics are a fixed set for now; user-defined chips are out of scope.
- Editing topics on existing entries and filtering history by topic are not included.

## Test plan
- [ ] Open `/journal` and confirm five chips appear above the text area.
- [ ] Select a chip → accent selected state; click again → deselects.
- [ ] Select three chips → remaining chips are greyed/disabled; deselecting one re-enables the others.
- [ ] Save an entry with 0–3 topics and confirm success toast / cleared composer.
- [ ] Open `/journal/history` and confirm topics show between date and body (and that entries without topics look unchanged).
- [ ] Send invalid topics via API (unknown string, >3, duplicates, non-array) and confirm `400` responses.