### PR TITLE
Weekly journal summary V1 (Sunday ritual + local window bypass)

### DIFF
--- a/.cursor/rules/engineering-principles.mdc
+++ b/.cursor/rules/engineering-principles.mdc
@@ -72,3 +72,13 @@ Avoid adding speculative improvements.
 Before making large architectural changes, explain the reasoning.
 
 Prefer plans before implementation.
+
+---
+
+## Language
+
+Write code, comments, prompts, docs, and new developer-facing strings in English.
+
+Do not add new Spanish (or other non-English) source text in the codebase.
+
+User-facing product copy may remain in Spanish when that is an intentional product choice; keep those strings in UI/copy layers, not in prompts, comments, or backend logic.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -104,3 +104,23 @@ In production we hit authentication instability: `/auth/me` returned unauthorize
 - Need DNS + Vercel domain management for `api.detoxmental.es`
 - Need stricter env coordination (`FRONTEND_ORIGIN`, `API_PUBLIC_URL`, frontend `VITE_API_URL`)
 - Must redeploy both projects when domain/env wiring changes
+
+### 2026-08-01 — Weekly journal summary: on-demand generation, not cron
+
+**Decision:**  
+Generate the weekly journal reflection **on user click** during a limited Sunday window, persist **one row per user per ISO week**, and produce **summary + best quote + Socratic prompt in a single LLM call**. Full design: `docs/weekly-journal-summary.md`.
+
+**Why this option was chosen:**  
+- The product goal is a **ritual** (user is present), not a batch report emailed into the void.
+- The repo has **no job runner / Vercel cron** today; on-demand fits the current Express-on-Vercel model.
+- One HF `chatCompletion` keeps us closer to the **20s `maxDuration`** budget than three sequential calls.
+- Persisting the result makes re-opening the page cheap and prevents repeat spend / prompt drift for the same week.
+
+**Why obvious alternatives were rejected:**  
+- **Cron / precompute for every user:** Requires new infra and pays for users who never open the summary.
+- **Three separate model calls (one per section):** Simpler prompts, but higher latency and timeout risk on Vercel.
+- **Client-only window gate (like promo):** Fine for UX copy, insufficient for creation authorization; server must enforce.
+- **Regenerate freely:** Undermines the “once a week” scarcity and increases cost/abuse surface.
+
+**What would trigger revisiting:**  
+Persistent timeouts, desire for push/email reminders, or a multi-week archive/compare product surface.

--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -57,12 +57,13 @@ Use **test** keys and a **test** price while developing; no real money moves in 
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `HF_TOKEN` | Yes for `/chat` and journal image transcription | Hugging Face API token. Needs "Inference Providers" permission. Used by the chat controller and by journal handwriting transcription. |
+| `HF_TOKEN` | Yes for `/chat`, journal image transcription, and weekly journal summaries | Hugging Face API token. Needs "Inference Providers" permission. Used by the chat controller, journal handwriting transcription, and weekly journal summary generation. |
 | `HF_JOURNAL_VISION_MODEL` | No | Vision-language model used to transcribe handwritten journal images. Defaults to `Qwen/Qwen3-VL-30B-A3B-Instruct:novita`. Override to swap models without code changes. |
+| `HF_JOURNAL_SUMMARY_MODEL` | No | Text model for weekly journal summaries. Defaults to `meta-llama/Llama-3.1-8B-Instruct:novita`. |
 
 Journal transcription uploads are processed in memory only: the image is sent to the model and never written to disk or the database. Only the transcribed text is returned to the client for review before saving.
 
-**Production (backend Vercel project):** Set `HF_TOKEN` (required for chat and journal scan-to-text) and optionally `HF_JOURNAL_VISION_MODEL` on the **backend** project (`detox-mental-backend` / `api.detoxmental.es`), not the frontend project.
+**Production (backend Vercel project):** Set `HF_TOKEN` (required for chat, journal scan-to-text, and weekly summaries) and optionally `HF_JOURNAL_VISION_MODEL` / `HF_JOURNAL_SUMMARY_MODEL` on the **backend** project (`detox-mental-backend` / `api.detoxmental.es`), not the frontend project.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,12 @@ State: ✅ Released on May 9th, 2026.
 Stripe integration and membership options.
 The project evolves from a self-contained prototype into a sustainable product.
 
+### Next — Weekly Journal Summary (self-reflection ritual)
+
+State: 🧭 Designed (see `docs/weekly-journal-summary.md`). Not implemented yet.
+
+Turns stored journal entries into a Sunday-only AI reflection: weekly topic summary, a “best quote” from the user’s own writing, and a Socratic prompt. Generated on demand during a limited time window; persisted once per week.
+
 ### Future Product Directions
 
 - Full translation of the app into English, opening Detox Mental to broader English-speaking markets.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ The project evolves from a self-contained prototype into a sustainable product.
 
 ### Next — Weekly Journal Summary (self-reflection ritual)
 
-State: 🧭 Designed (see `docs/weekly-journal-summary.md`). Not implemented yet.
+State: 🚧 V1 implemented on branch (Sunday window bypassed for local testing). See `docs/weekly-journal-summary.md`.
 
 Turns stored journal entries into a Sunday-only AI reflection: weekly topic summary, a “best quote” from the user’s own writing, and a Socratic prompt. Generated on demand during a limited time window; persisted once per week.
 

--- a/backend/src/auth/auth.routes.js
+++ b/backend/src/auth/auth.routes.js
@@ -13,6 +13,10 @@ import {
   uploadJournalImage,
   postJournalTranscription,
 } from '../journalTranscription/journalTranscription.controller.js';
+import {
+  getCurrentJournalSummary,
+  postCurrentJournalSummary,
+} from '../journalSummaries/journalSummaries.controller.js';
 import { requireAuth } from './auth.middleware.js';
 
 const router = express.Router();
@@ -30,6 +34,16 @@ router.post(
   requireAuth,
   uploadJournalImage,
   postJournalTranscription,
+);
+router.get(
+  '/me/journal-summaries/current',
+  requireAuth,
+  getCurrentJournalSummary,
+);
+router.post(
+  '/me/journal-summaries/current',
+  requireAuth,
+  postCurrentJournalSummary,
 );
 router.get('/me', requireAuth, me);
 

--- a/backend/src/db/README.md
+++ b/backend/src/db/README.md
@@ -330,6 +330,12 @@ users (1) ──────< (N) magic_link_tokens
 \i backend/src/db/migrations/003_journal_entries.sql
 ```
 
+### Journal Weekly Summaries
+```sql
+-- Run after journal_entries migration
+\i backend/src/db/migrations/004_journal_weekly_summaries.sql
+```
+
 ### Verify Migration Success
 ```sql
 -- Check all tables created

--- a/backend/src/db/README.md
+++ b/backend/src/db/README.md
@@ -177,6 +177,33 @@ Stores free-form journal entries for the user diary (`/journal`). Separate from 
 
 ---
 
+### 5c. `journal_weekly_summaries`
+
+Stores the once-per-week AI reflection generated from `journal_entries` (`/journal/summary`).
+
+**Columns:**
+- `id` (UUID, PK)
+- `user_id` (UUID, FK → users.id)
+- `week_start` / `week_end` (DATE): Monday–Sunday of the ISO week in Europe/Madrid
+- `period_start` / `period_end` (TIMESTAMPTZ): UTC range used to select entries
+- `summary_text` (TEXT): Plain weekly overview
+- `main_topics` (TEXT[]): Model-derived topic labels
+- `best_quote` (TEXT): Highlighted sentence from the user’s writing
+- `best_quote_entry_id` (UUID, FK → journal_entries.id, nullable, ON DELETE SET NULL)
+- `socratic_text` (TEXT): Challenging Socratic question/prompt
+- `entry_count` (INTEGER): How many entries were included
+- `model_id` (TEXT, nullable): HF model that produced the row
+- `created_at` (TIMESTAMPTZ)
+
+**Constraints:**
+- `UNIQUE (user_id, week_start)` — one summary per user per week
+- Non-empty checks on summary / quote / socratic text
+
+**Indexes:**
+- `idx_journal_weekly_summaries_user_created`: User history ordering
+
+---
+
 ### 6. `classifications`
 
 Stores cognitive distortion classifications for thoughts.

--- a/backend/src/db/migrations/004_journal_weekly_summaries.sql
+++ b/backend/src/db/migrations/004_journal_weekly_summaries.sql
@@ -1,0 +1,54 @@
+-- =====================================================
+-- Detox Mental Database Schema Migration
+-- Version: 004 - Journal Weekly Summaries
+-- Description: Persist once-per-week AI journal reflections
+-- =====================================================
+
+CREATE TABLE journal_weekly_summaries (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    week_start DATE NOT NULL,
+    week_end DATE NOT NULL,
+    period_start TIMESTAMP WITH TIME ZONE NOT NULL,
+    period_end TIMESTAMP WITH TIME ZONE NOT NULL,
+    summary_text TEXT NOT NULL,
+    main_topics TEXT[] NOT NULL DEFAULT '{}',
+    best_quote TEXT NOT NULL,
+    best_quote_entry_id UUID,
+    socratic_text TEXT NOT NULL,
+    entry_count INTEGER NOT NULL,
+    model_id TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_journal_weekly_summaries_user_id
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_journal_weekly_summaries_best_quote_entry_id
+        FOREIGN KEY (best_quote_entry_id)
+        REFERENCES journal_entries(id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT journal_weekly_summaries_entry_count_positive
+        CHECK (entry_count >= 0),
+
+    CONSTRAINT journal_weekly_summaries_summary_not_empty
+        CHECK (LENGTH(TRIM(summary_text)) > 0),
+
+    CONSTRAINT journal_weekly_summaries_quote_not_empty
+        CHECK (LENGTH(TRIM(best_quote)) > 0),
+
+    CONSTRAINT journal_weekly_summaries_socratic_not_empty
+        CHECK (LENGTH(TRIM(socratic_text)) > 0),
+
+    CONSTRAINT journal_weekly_summaries_user_week_unique
+        UNIQUE (user_id, week_start)
+);
+
+CREATE INDEX idx_journal_weekly_summaries_user_created
+    ON journal_weekly_summaries (user_id, created_at DESC);
+
+-- =====================================================
+-- END OF MIGRATION
+-- =====================================================

--- a/backend/src/journalSummaries/journalSummaries.controller.js
+++ b/backend/src/journalSummaries/journalSummaries.controller.js
@@ -1,0 +1,141 @@
+import {
+  buildWindowPayload,
+  getWeekBounds,
+  isSummaryWindowOpen,
+  MIN_ENTRIES_FOR_SUMMARY,
+} from './summaryWindow.js';
+import {
+  countJournalEntriesInRange,
+  createWeeklySummary,
+  getWeeklySummaryForUser,
+  listJournalEntriesInRange,
+} from './journalSummaries.service.js';
+import { generateWeeklySummaryContent } from './journalSummaries.generation.js';
+
+const uniqueViolation = (err) =>
+  err?.code === '23505' || /duplicate key/i.test(String(err?.message ?? ''));
+
+const buildCurrentPayload = async (userId, now = new Date()) => {
+  const bounds = getWeekBounds(now);
+  const window = buildWindowPayload(now);
+  const [entryCount, summary] = await Promise.all([
+    countJournalEntriesInRange(userId, bounds.periodStart, bounds.periodEnd),
+    getWeeklySummaryForUser(userId, bounds.weekStart),
+  ]);
+
+  const canCreate =
+    window.open &&
+    !summary &&
+    entryCount >= MIN_ENTRIES_FOR_SUMMARY;
+
+  return {
+    weekStart: bounds.weekStart,
+    weekEnd: bounds.weekEnd,
+    window,
+    entryCount,
+    minEntries: MIN_ENTRIES_FOR_SUMMARY,
+    canCreate,
+    summary,
+  };
+};
+
+export const getCurrentJournalSummary = async (req, res) => {
+  try {
+    const payload = await buildCurrentPayload(req.user.id);
+    return res.status(200).json(payload);
+  } catch (err) {
+    console.error('[journal-summaries GET current]', err);
+    return res.status(500).json({ message: 'Error al cargar el resumen.' });
+  }
+};
+
+export const postCurrentJournalSummary = async (req, res) => {
+  try {
+    const now = new Date();
+    if (!isSummaryWindowOpen(now)) {
+      return res.status(403).json({
+        message:
+          'El resumen semanal solo se puede crear el domingo de 12:00 a 18:00 (hora de Madrid).',
+      });
+    }
+
+    const bounds = getWeekBounds(now);
+    const existing = await getWeeklySummaryForUser(
+      req.user.id,
+      bounds.weekStart,
+    );
+    if (existing) {
+      return res.status(409).json({
+        message: 'Ya existe un resumen para esta semana.',
+        summary: existing,
+      });
+    }
+
+    const entries = await listJournalEntriesInRange(
+      req.user.id,
+      bounds.periodStart,
+      bounds.periodEnd,
+    );
+
+    if (entries.length < MIN_ENTRIES_FOR_SUMMARY) {
+      return res.status(422).json({
+        message: `Necesitas al menos ${MIN_ENTRIES_FOR_SUMMARY} entradas esta semana para crear el resumen.`,
+        entryCount: entries.length,
+        minEntries: MIN_ENTRIES_FOR_SUMMARY,
+      });
+    }
+
+    let generated;
+    try {
+      generated = await generateWeeklySummaryContent({
+        entries,
+        weekStart: bounds.weekStart,
+        weekEnd: bounds.weekEnd,
+      });
+    } catch (genErr) {
+      console.error('[journal-summaries POST generate]', genErr);
+      if (genErr.code === 'missing_hf_token') {
+        return res.status(503).json({
+          message: 'El servicio de resumen no está configurado.',
+        });
+      }
+      return res.status(502).json({
+        message:
+          'No se pudo generar el resumen. Inténtalo de nuevo en unos momentos.',
+      });
+    }
+
+    try {
+      const summary = await createWeeklySummary({
+        userId: req.user.id,
+        weekStart: bounds.weekStart,
+        weekEnd: bounds.weekEnd,
+        periodStart: bounds.periodStart,
+        periodEnd: bounds.periodEnd,
+        summaryText: generated.summaryText,
+        mainTopics: generated.mainTopics,
+        bestQuote: generated.bestQuote,
+        bestQuoteEntryId: generated.bestQuoteEntryId,
+        socraticText: generated.socraticText,
+        entryCount: entries.length,
+        modelId: generated.modelId,
+      });
+      return res.status(201).json({ summary });
+    } catch (insertErr) {
+      if (uniqueViolation(insertErr)) {
+        const summary = await getWeeklySummaryForUser(
+          req.user.id,
+          bounds.weekStart,
+        );
+        return res.status(409).json({
+          message: 'Ya existe un resumen para esta semana.',
+          summary,
+        });
+      }
+      throw insertErr;
+    }
+  } catch (err) {
+    console.error('[journal-summaries POST current]', err);
+    return res.status(500).json({ message: 'Error al crear el resumen.' });
+  }
+};

--- a/backend/src/journalSummaries/journalSummaries.generation.js
+++ b/backend/src/journalSummaries/journalSummaries.generation.js
@@ -1,0 +1,57 @@
+import { InferenceClient } from '@huggingface/inference';
+import { buildSummaryMessages } from './prompts.js';
+import {
+  findBestQuoteEntryId,
+  parseSummaryOutput,
+} from './parseSummaryOutput.js';
+
+const DEFAULT_SUMMARY_MODEL = 'meta-llama/Llama-3.1-8B-Instruct:novita';
+
+export const getSummaryModelId = () =>
+  process.env.HF_JOURNAL_SUMMARY_MODEL || DEFAULT_SUMMARY_MODEL;
+
+/**
+ * Call HF and return normalized summary fields + quote entry match.
+ * @throws Error with code-like message prefixes for controller mapping
+ */
+export const generateWeeklySummaryContent = async ({
+  entries,
+  weekStart,
+  weekEnd,
+}) => {
+  if (!process.env.HF_TOKEN) {
+    const err = new Error('missing_hf_token');
+    err.code = 'missing_hf_token';
+    throw err;
+  }
+
+  const modelId = getSummaryModelId();
+  const client = new InferenceClient(process.env.HF_TOKEN);
+  const messages = buildSummaryMessages({ entries, weekStart, weekEnd });
+
+  const response = await client.chatCompletion({
+    model: modelId,
+    messages,
+    max_tokens: 900,
+    temperature: 0.5,
+  });
+
+  const raw = response.choices?.[0]?.message?.content ?? '';
+  const parsed = parseSummaryOutput(raw);
+  if (!parsed.ok) {
+    const err = new Error(parsed.error);
+    err.code = 'invalid_model_output';
+    throw err;
+  }
+
+  const bestQuoteEntryId = findBestQuoteEntryId(
+    parsed.value.bestQuote,
+    entries,
+  );
+
+  return {
+    ...parsed.value,
+    bestQuoteEntryId,
+    modelId,
+  };
+};

--- a/backend/src/journalSummaries/journalSummaries.service.js
+++ b/backend/src/journalSummaries/journalSummaries.service.js
@@ -1,0 +1,115 @@
+import pool from '../db/db.js';
+
+const toDateOnly = (value) => {
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (typeof value === 'string') return value.slice(0, 10);
+  return value;
+};
+
+const toIso = (value) => {
+  if (value instanceof Date) return value.toISOString();
+  return value;
+};
+
+const mapSummaryRow = (row) => ({
+  id: row.id,
+  weekStart: toDateOnly(row.week_start),
+  weekEnd: toDateOnly(row.week_end),
+  periodStart: toIso(row.period_start),
+  periodEnd: toIso(row.period_end),
+  summaryText: row.summary_text,
+  mainTopics: row.main_topics ?? [],
+  bestQuote: row.best_quote,
+  bestQuoteEntryId: row.best_quote_entry_id,
+  socraticText: row.socratic_text,
+  entryCount: row.entry_count,
+  modelId: row.model_id,
+  createdAt: toIso(row.created_at),
+});
+
+export const listJournalEntriesInRange = async (userId, periodStart, periodEnd) => {
+  const { rows } = await pool.query(
+    `SELECT id, content, topics, created_at
+     FROM journal_entries
+     WHERE user_id = $1
+       AND created_at >= $2
+       AND created_at < $3
+     ORDER BY created_at ASC`,
+    [userId, periodStart, periodEnd],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    content: row.content,
+    topics: row.topics ?? [],
+    createdAt: row.created_at,
+  }));
+};
+
+export const countJournalEntriesInRange = async (
+  userId,
+  periodStart,
+  periodEnd,
+) => {
+  const { rows } = await pool.query(
+    `SELECT COUNT(*)::int AS count
+     FROM journal_entries
+     WHERE user_id = $1
+       AND created_at >= $2
+       AND created_at < $3`,
+    [userId, periodStart, periodEnd],
+  );
+  return rows[0]?.count ?? 0;
+};
+
+export const getWeeklySummaryForUser = async (userId, weekStart) => {
+  const { rows } = await pool.query(
+    `SELECT id, user_id, week_start, week_end, period_start, period_end,
+            summary_text, main_topics, best_quote, best_quote_entry_id,
+            socratic_text, entry_count, model_id, created_at
+     FROM journal_weekly_summaries
+     WHERE user_id = $1 AND week_start = $2`,
+    [userId, weekStart],
+  );
+  return rows[0] ? mapSummaryRow(rows[0]) : null;
+};
+
+export const createWeeklySummary = async ({
+  userId,
+  weekStart,
+  weekEnd,
+  periodStart,
+  periodEnd,
+  summaryText,
+  mainTopics,
+  bestQuote,
+  bestQuoteEntryId,
+  socraticText,
+  entryCount,
+  modelId,
+}) => {
+  const { rows } = await pool.query(
+    `INSERT INTO journal_weekly_summaries (
+       user_id, week_start, week_end, period_start, period_end,
+       summary_text, main_topics, best_quote, best_quote_entry_id,
+       socratic_text, entry_count, model_id
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+     RETURNING id, user_id, week_start, week_end, period_start, period_end,
+               summary_text, main_topics, best_quote, best_quote_entry_id,
+               socratic_text, entry_count, model_id, created_at`,
+    [
+      userId,
+      weekStart,
+      weekEnd,
+      periodStart,
+      periodEnd,
+      summaryText,
+      mainTopics,
+      bestQuote,
+      bestQuoteEntryId,
+      socraticText,
+      entryCount,
+      modelId,
+    ],
+  );
+  return mapSummaryRow(rows[0]);
+};

--- a/backend/src/journalSummaries/parseSummaryOutput.js
+++ b/backend/src/journalSummaries/parseSummaryOutput.js
@@ -1,0 +1,105 @@
+import { normalizeLlmOutput } from '../onboarding/parsers/normalizeLlmOutput.js';
+
+const MAX_TOPICS = 5;
+
+/** Pull a JSON object out of raw model text (fences / surrounding prose). */
+export const extractJsonObject = (raw) => {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1].trim() : trimmed;
+
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    const start = candidate.indexOf('{');
+    const end = candidate.lastIndexOf('}');
+    if (start === -1 || end <= start) return null;
+    try {
+      return JSON.parse(candidate.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+};
+
+const asNonEmptyString = (value) => {
+  if (typeof value !== 'string') return null;
+  const normalized = normalizeLlmOutput(value);
+  return normalized.length > 0 ? normalized : null;
+};
+
+const asTopicList = (value) => {
+  if (!Array.isArray(value)) return [];
+  const topics = [];
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const topic = item.trim().replace(/\s+/g, ' ');
+    if (!topic) continue;
+    if (!topics.includes(topic)) topics.push(topic);
+    if (topics.length >= MAX_TOPICS) break;
+  }
+  return topics;
+};
+
+/**
+ * Validate and normalize model JSON into the three summary sections.
+ * @returns {{ ok: true, value } | { ok: false, error: string }}
+ */
+export const parseSummaryOutput = (raw) => {
+  const parsed = extractJsonObject(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, error: 'invalid_json' };
+  }
+
+  const summary = asNonEmptyString(parsed.summary);
+  const bestQuote = asNonEmptyString(parsed.bestQuote);
+  const socratic = asNonEmptyString(parsed.socratic);
+  const mainTopics = asTopicList(parsed.mainTopics);
+
+  if (!summary || !bestQuote || !socratic) {
+    return { ok: false, error: 'missing_fields' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      summaryText: summary,
+      mainTopics,
+      bestQuote,
+      socraticText: socratic,
+    },
+  };
+};
+
+const normalizeForMatch = (text) =>
+  String(text)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+/** Best-effort match of quote text to a source entry id. */
+export const findBestQuoteEntryId = (quote, entries) => {
+  const needle = normalizeForMatch(quote);
+  if (!needle || !Array.isArray(entries)) return null;
+
+  for (const entry of entries) {
+    const haystack = normalizeForMatch(entry.content);
+    if (haystack.includes(needle)) return entry.id;
+  }
+
+  // Soften: quote may be a shortened fragment with ellipsis
+  const compact = needle.replace(/[.…]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (compact.length >= 12) {
+    for (const entry of entries) {
+      const haystack = normalizeForMatch(entry.content);
+      if (haystack.includes(compact)) return entry.id;
+    }
+  }
+
+  return null;
+};

--- a/backend/src/journalSummaries/parseSummaryOutput.test.js
+++ b/backend/src/journalSummaries/parseSummaryOutput.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractJsonObject,
+  findBestQuoteEntryId,
+  parseSummaryOutput,
+} from './parseSummaryOutput.js';
+
+test('extractJsonObject parses fenced JSON', () => {
+  const raw = '```json\n{"summary":"Hola","mainTopics":["A"],"bestQuote":"x","socratic":"¿Y?"}\n```';
+  const obj = extractJsonObject(raw);
+  assert.equal(obj.summary, 'Hola');
+});
+
+test('parseSummaryOutput normalizes fields', () => {
+  const result = parseSummaryOutput(
+    JSON.stringify({
+      summary: '  esta semana pensaste en el trabajo.  ',
+      mainTopics: ['Trabajo', 'Trabajo', '  ', 'Miedo'],
+      bestQuote: '"nunca es suficiente"',
+      socratic: '¿qué evidencia tienes de que nunca es suficiente?',
+    }),
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.value.summaryText.startsWith('Esta semana'), true);
+  assert.deepEqual(result.value.mainTopics, ['Trabajo', 'Miedo']);
+  assert.equal(result.value.bestQuote, 'Nunca es suficiente');
+  assert.match(result.value.socraticText, /^¿Qué evidencia/i);
+});
+
+test('parseSummaryOutput rejects missing fields', () => {
+  const result = parseSummaryOutput('{"summary":"solo esto"}');
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'missing_fields');
+});
+
+test('findBestQuoteEntryId matches source entry ignoring case/accents', () => {
+  const entries = [
+    { id: 'a', content: 'Hoy me sentí cansado.' },
+    { id: 'b', content: 'Nunca es suficiente para mí.' },
+  ];
+  assert.equal(findBestQuoteEntryId('nunca es suficiente', entries), 'b');
+  assert.equal(findBestQuoteEntryId('frase inventada total', entries), null);
+});

--- a/backend/src/journalSummaries/prompts.js
+++ b/backend/src/journalSummaries/prompts.js
@@ -1,0 +1,70 @@
+const MAX_INPUT_CHARS = 10000;
+
+const formatEntryBlock = (entry, index) => {
+  const topics =
+    Array.isArray(entry.topics) && entry.topics.length > 0
+      ? entry.topics.join(', ')
+      : 'sin etiquetar';
+  const when = entry.createdAt
+    ? new Date(entry.createdAt).toISOString()
+    : 'fecha desconocida';
+  return [
+    `### Entrada ${index + 1}`,
+    `id: ${entry.id}`,
+    `fecha: ${when}`,
+    `temas: ${topics}`,
+    'texto:',
+    entry.content,
+  ].join('\n');
+};
+
+/** Newest-first truncation so recent writing is preferred under the char budget. */
+export const buildEntriesPromptSection = (entries) => {
+  const ordered = [...entries].sort(
+    (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
+  );
+
+  const blocks = [];
+  let used = 0;
+  for (const entry of ordered) {
+    const block = formatEntryBlock(entry, blocks.length);
+    const next = used + block.length + 2;
+    if (blocks.length > 0 && next > MAX_INPUT_CHARS) break;
+    blocks.push(block);
+    used = next;
+  }
+
+  // Present chronologically (oldest → newest) for the model
+  return blocks.reverse().join('\n\n');
+};
+
+export const buildSummaryMessages = ({ entries, weekStart, weekEnd }) => {
+  const entriesSection = buildEntriesPromptSection(entries);
+
+  const system = [
+    'Eres un espejo de pensamiento para Detox Mental, una herramienta de autorreflexión.',
+    'Recibes entradas de diario de una persona en español. Debes devolver SOLO un objeto JSON válido, sin markdown ni prosa alrededor.',
+    'Esquema exacto:',
+    '{"summary":"string","mainTopics":["string"],"bestQuote":"string","socratic":"string"}',
+    'Reglas:',
+    '- summary: 2–4 párrafos cortos que reflejen con neutralidad lo escrito y los temas principales. No inventes hechos. No diagnostiques. No uses jerga clínica.',
+    '- mainTopics: entre 2 y 5 etiquetas cortas (pueden alinearse con Trabajo, Interpersonal, Reflexión, Sabiduría, Preocupaciones u otras precisas).',
+    '- bestQuote: una frase o pasaje BREVE tomado de forma casi literal del texto del usuario. No inventes. Si hay que recortar, usa elipsis…',
+    '- socratic: UNA sola pregunta o desafío al estilo de Sócrates: afilado, exigente, que obligue a examinar una creencia o contradicción. No aconsejes blandamente. No sermonees. No digas "deberías". No diagnostiques.',
+    '- Todo el contenido en español.',
+    '- Si el material es escaso, sé honesto en el summary sin rellenar con generalidades.',
+  ].join('\n');
+
+  const user = [
+    `Semana del ${weekStart} al ${weekEnd} (Europe/Madrid).`,
+    `Número de entradas incluidas: ${entries.length}.`,
+    '',
+    'Entradas del diario:',
+    entriesSection,
+  ].join('\n');
+
+  return [
+    { role: 'system', content: system },
+    { role: 'user', content: user },
+  ];
+};

--- a/backend/src/journalSummaries/prompts.js
+++ b/backend/src/journalSummaries/prompts.js
@@ -4,16 +4,16 @@ const formatEntryBlock = (entry, index) => {
   const topics =
     Array.isArray(entry.topics) && entry.topics.length > 0
       ? entry.topics.join(', ')
-      : 'sin etiquetar';
+      : 'untagged';
   const when = entry.createdAt
     ? new Date(entry.createdAt).toISOString()
-    : 'fecha desconocida';
+    : 'unknown date';
   return [
-    `### Entrada ${index + 1}`,
+    `### Entry ${index + 1}`,
     `id: ${entry.id}`,
-    `fecha: ${when}`,
-    `temas: ${topics}`,
-    'texto:',
+    `date: ${when}`,
+    `topics: ${topics}`,
+    'text:',
     entry.content,
   ].join('\n');
 };
@@ -42,24 +42,24 @@ export const buildSummaryMessages = ({ entries, weekStart, weekEnd }) => {
   const entriesSection = buildEntriesPromptSection(entries);
 
   const system = [
-    'Eres un espejo de pensamiento para Detox Mental, una herramienta de autorreflexión.',
-    'Recibes entradas de diario de una persona en español. Debes devolver SOLO un objeto JSON válido, sin markdown ni prosa alrededor.',
-    'Esquema exacto:',
+    'You are a thinking mirror for Detox Mental, a self-reflection tool.',
+    'You receive a person\'s journal entries (usually in Spanish). Return ONLY a valid JSON object, with no markdown and no prose around it.',
+    'Exact schema:',
     '{"summary":"string","mainTopics":["string"],"bestQuote":"string","socratic":"string"}',
-    'Reglas:',
-    '- summary: 2–4 párrafos cortos que reflejen con neutralidad lo escrito y los temas principales. No inventes hechos. No diagnostiques. No uses jerga clínica.',
-    '- mainTopics: entre 2 y 5 etiquetas cortas (pueden alinearse con Trabajo, Interpersonal, Reflexión, Sabiduría, Preocupaciones u otras precisas).',
-    '- bestQuote: una frase o pasaje BREVE tomado de forma casi literal del texto del usuario. No inventes. Si hay que recortar, usa elipsis…',
-    '- socratic: UNA sola pregunta o desafío al estilo de Sócrates: afilado, exigente, que obligue a examinar una creencia o contradicción. No aconsejes blandamente. No sermonees. No digas "deberías". No diagnostiques.',
-    '- Todo el contenido en español.',
-    '- Si el material es escaso, sé honesto en el summary sin rellenar con generalidades.',
+    'Rules:',
+    '- summary: 2–4 short paragraphs that mirror what they wrote and the main themes. Address the user directly in second person (tú / "you"), as if speaking to them — e.g. "Has estado pensando…", never third person like "the author" / "el autor del diario". Do not invent facts. Do not diagnose. Do not use clinical jargon.',
+    '- mainTopics: 2 to 5 short labels (may align with Trabajo, Interpersonal, Reflexión, Sabiduría, Preocupaciones, or other precise labels).',
+    '- bestQuote: one BRIEF sentence or passage taken nearly verbatim from the user\'s text. Do not invent. If you must shorten it, use an ellipsis…',
+    '- socratic: ONE sharp Socratic question or challenge that forces examination of a belief or contradiction. No soft advice. No sermons. Do not say "you should" / "deberías". Do not diagnose.',
+    '- Write every user-facing string value (summary, mainTopics, bestQuote, socratic) in Spanish.',
+    '- If the material is sparse, be honest in the summary; do not pad with generic filler.',
   ].join('\n');
 
   const user = [
-    `Semana del ${weekStart} al ${weekEnd} (Europe/Madrid).`,
-    `Número de entradas incluidas: ${entries.length}.`,
+    `Week from ${weekStart} to ${weekEnd} (Europe/Madrid).`,
+    `Number of entries included: ${entries.length}.`,
     '',
-    'Entradas del diario:',
+    'Journal entries:',
     entriesSection,
   ].join('\n');
 

--- a/backend/src/journalSummaries/summaryWindow.js
+++ b/backend/src/journalSummaries/summaryWindow.js
@@ -1,0 +1,193 @@
+/**
+ * Week bounds and Sunday creation window for journal summaries.
+ * Product timezone: Europe/Madrid. Week = Monday 00:00 → next Monday 00:00.
+ * Creation window: Sunday 12:00–18:00 (inclusive start, exclusive end).
+ */
+
+export const SUMMARY_TIMEZONE = 'Europe/Madrid';
+export const MIN_ENTRIES_FOR_SUMMARY = 2;
+
+// TEMP for local/dev testing: keep false so creation is not Sunday-gated.
+// Set to true before shipping the Sunday ritual.
+export const ENFORCE_SUMMARY_WINDOW = false;
+
+const WINDOW_START_HOUR = 12;
+const WINDOW_END_HOUR = 18;
+
+const pad2 = (n) => String(n).padStart(2, '0');
+
+const toDateString = (year, month, day) =>
+  `${year}-${pad2(month)}-${pad2(day)}`;
+
+/** Local calendar/clock parts for `date` in `timeZone`. */
+export const getZonedParts = (date, timeZone = SUMMARY_TIMEZONE) => {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    weekday: 'short',
+    hourCycle: 'h23',
+  });
+  const parts = Object.fromEntries(
+    dtf
+      .formatToParts(date)
+      .filter((p) => p.type !== 'literal')
+      .map((p) => [p.type, p.value]),
+  );
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    hour: Number(parts.hour),
+    minute: Number(parts.minute),
+    second: Number(parts.second),
+    weekday: parts.weekday,
+  };
+};
+
+/** Offset (ms) such that: utcMs + offset ≈ zoned wall-clock as UTC fields. */
+const getTimeZoneOffsetMs = (date, timeZone) => {
+  const parts = getZonedParts(date, timeZone);
+  const asUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return asUtc - date.getTime();
+};
+
+/** Convert a wall-clock time in `timeZone` to a UTC Date. */
+export const zonedLocalToUtc = (
+  year,
+  month,
+  day,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  timeZone = SUMMARY_TIMEZONE,
+) => {
+  const utcGuess = Date.UTC(year, month - 1, day, hour, minute, second);
+  const offset1 = getTimeZoneOffsetMs(new Date(utcGuess), timeZone);
+  const utc1 = Date.UTC(year, month - 1, day, hour, minute, second) - offset1;
+  const offset2 = getTimeZoneOffsetMs(new Date(utc1), timeZone);
+  return new Date(
+    Date.UTC(year, month - 1, day, hour, minute, second) - offset2,
+  );
+};
+
+const WEEKDAY_TO_OFFSET = {
+  Mon: 0,
+  Tue: 1,
+  Wed: 2,
+  Thu: 3,
+  Fri: 4,
+  Sat: 5,
+  Sun: 6,
+};
+
+const addDaysToYmd = (year, month, day, deltaDays) => {
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  utc.setUTCDate(utc.getUTCDate() + deltaDays);
+  return {
+    year: utc.getUTCFullYear(),
+    month: utc.getUTCMonth() + 1,
+    day: utc.getUTCDate(),
+  };
+};
+
+/**
+ * ISO-style week containing `now` in the product timezone:
+ * Monday 00:00 inclusive → next Monday 00:00 exclusive.
+ */
+export const getWeekBounds = (now = new Date(), timeZone = SUMMARY_TIMEZONE) => {
+  const parts = getZonedParts(now, timeZone);
+  const daysFromMonday = WEEKDAY_TO_OFFSET[parts.weekday];
+  if (daysFromMonday === undefined) {
+    throw new Error(`Unexpected weekday: ${parts.weekday}`);
+  }
+
+  const monday = addDaysToYmd(parts.year, parts.month, parts.day, -daysFromMonday);
+  const nextMonday = addDaysToYmd(monday.year, monday.month, monday.day, 7);
+  const sunday = addDaysToYmd(monday.year, monday.month, monday.day, 6);
+
+  const periodStart = zonedLocalToUtc(
+    monday.year,
+    monday.month,
+    monday.day,
+    0,
+    0,
+    0,
+    timeZone,
+  );
+  const periodEnd = zonedLocalToUtc(
+    nextMonday.year,
+    nextMonday.month,
+    nextMonday.day,
+    0,
+    0,
+    0,
+    timeZone,
+  );
+
+  const opensAt = zonedLocalToUtc(
+    sunday.year,
+    sunday.month,
+    sunday.day,
+    WINDOW_START_HOUR,
+    0,
+    0,
+    timeZone,
+  );
+  const closesAt = zonedLocalToUtc(
+    sunday.year,
+    sunday.month,
+    sunday.day,
+    WINDOW_END_HOUR,
+    0,
+    0,
+    timeZone,
+  );
+
+  return {
+    weekStart: toDateString(monday.year, monday.month, monday.day),
+    weekEnd: toDateString(sunday.year, sunday.month, sunday.day),
+    periodStart,
+    periodEnd,
+    opensAt,
+    closesAt,
+    timezone: timeZone,
+  };
+};
+
+/** Whether creation is allowed for `now` (respects ENFORCE_SUMMARY_WINDOW). */
+export const isSummaryWindowOpen = (
+  now = new Date(),
+  timeZone = SUMMARY_TIMEZONE,
+) => {
+  if (!ENFORCE_SUMMARY_WINDOW) return true;
+
+  const bounds = getWeekBounds(now, timeZone);
+  const t = now.getTime();
+  return t >= bounds.opensAt.getTime() && t < bounds.closesAt.getTime();
+};
+
+export const buildWindowPayload = (
+  now = new Date(),
+  timeZone = SUMMARY_TIMEZONE,
+) => {
+  const bounds = getWeekBounds(now, timeZone);
+  return {
+    timezone: timeZone,
+    open: isSummaryWindowOpen(now, timeZone),
+    enforced: ENFORCE_SUMMARY_WINDOW,
+    opensAt: bounds.opensAt.toISOString(),
+    closesAt: bounds.closesAt.toISOString(),
+  };
+};

--- a/backend/src/journalSummaries/summaryWindow.test.js
+++ b/backend/src/journalSummaries/summaryWindow.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ENFORCE_SUMMARY_WINDOW,
+  getWeekBounds,
+  getZonedParts,
+  isSummaryWindowOpen,
+  zonedLocalToUtc,
+} from './summaryWindow.js';
+
+test('zonedLocalToUtc maps Madrid winter noon to 11:00 UTC', () => {
+  // 2026-01-11 is Sunday; CET = UTC+1
+  const utc = zonedLocalToUtc(2026, 1, 11, 12, 0, 0, 'Europe/Madrid');
+  assert.equal(utc.toISOString(), '2026-01-11T11:00:00.000Z');
+});
+
+test('zonedLocalToUtc maps Madrid summer noon to 10:00 UTC', () => {
+  // 2026-07-05 is Sunday; CEST = UTC+2
+  const utc = zonedLocalToUtc(2026, 7, 5, 12, 0, 0, 'Europe/Madrid');
+  assert.equal(utc.toISOString(), '2026-07-05T10:00:00.000Z');
+});
+
+test('getWeekBounds returns Monday–Sunday for a mid-week instant', () => {
+  // Wednesday 2026-07-29 15:00 Madrid = 13:00 UTC
+  const now = new Date('2026-07-29T13:00:00.000Z');
+  const bounds = getWeekBounds(now, 'Europe/Madrid');
+  assert.equal(bounds.weekStart, '2026-07-27');
+  assert.equal(bounds.weekEnd, '2026-08-02');
+  assert.equal(bounds.periodStart.toISOString(), '2026-07-26T22:00:00.000Z');
+  assert.equal(bounds.periodEnd.toISOString(), '2026-08-02T22:00:00.000Z');
+  assert.equal(bounds.opensAt.toISOString(), '2026-08-02T10:00:00.000Z');
+  assert.equal(bounds.closesAt.toISOString(), '2026-08-02T16:00:00.000Z');
+});
+
+test('getZonedParts reports Sunday in Madrid for window open instant', () => {
+  const openInstant = new Date('2026-08-02T10:00:00.000Z');
+  const parts = getZonedParts(openInstant, 'Europe/Madrid');
+  assert.equal(parts.weekday, 'Sun');
+  assert.equal(parts.hour, 12);
+});
+
+test('isSummaryWindowOpen respects ENFORCE_SUMMARY_WINDOW bypass', () => {
+  // A random Wednesday — when enforcement is off (current default), open is true.
+  const wednesday = new Date('2026-07-29T13:00:00.000Z');
+  if (!ENFORCE_SUMMARY_WINDOW) {
+    assert.equal(isSummaryWindowOpen(wednesday), true);
+  } else {
+    assert.equal(isSummaryWindowOpen(wednesday), false);
+    const sundayNoon = new Date('2026-08-02T10:30:00.000Z');
+    assert.equal(isSummaryWindowOpen(sundayNoon), true);
+    const sundayEvening = new Date('2026-08-02T16:00:00.000Z');
+    assert.equal(isSummaryWindowOpen(sundayEvening), false);
+  }
+});

--- a/docs/weekly-journal-summary.md
+++ b/docs/weekly-journal-summary.md
@@ -1,6 +1,6 @@
 # Weekly Journal Summary — Feature Design
 
-**Status:** Proposed (planning only — not implemented)  
+**Status:** V1 in progress (implementation on branch; Sunday window bypassed for local testing)  
 **Module:** Journaling (`/journal`)  
 **Product intent:** Turn saved writings into a weekly self-reflection ritual, not just storage.
 
@@ -255,16 +255,19 @@ Build in thin vertical slices; each slice shippable alone.
 - Frontend: states for closed / ready / loading / result / error (Vitest patterns like `Journal.test.jsx`).
 - Manual: generate with a week of mixed-topic entries; verify quote appears in source text.
 
-## 13. Open decisions (need product confirmation)
+## 13. Locked product decisions (V1)
 
-1. **Exact window** — Sunday 12:00–18:00 Europe/Madrid, or another schedule?
-2. **Missed window** — Can users create late (e.g. until Monday), or strictly Sunday only? Can they still *read* last week’s summary anytime?
-3. **Regeneration** — Forbidden in v1 (recommended), or allow one retry on failure only?
-4. **Minimum entries** — Any entry (`count >= 1`) vs require N entries / N characters?
-5. **Access** — All authenticated users (consistent with journal today) vs `paid` only?
-6. **Best quote strictness** — Must match an entry substring exactly, or allow light cleanup (punctuation/ellipsis)?
-7. **Copy language** — Spanish-only prompts/UI for v1?
-8. **Socratic tone** — Warm mentor vs sharper classic Socrates? Any topics the prompt must avoid?
+1. **Window:** Sunday 12:00–18:00, `Europe/Madrid`.
+2. **Missed Sunday:** No late creation. Summaries remain **readable anytime** after they exist.
+3. **Regeneration:** Never once stored. **Retry only when generation fails** (no row written).
+4. **Minimum writing:** At least **2 entries** in the week. No minimum character count.
+5. **Access:** All logged-in users (same as journal today).
+6. **Socratic tone:** Sharper / challenging (tunable later).
+7. **Copy language:** Spanish UI + Spanish prompts for v1.
+
+### Dev bypass
+
+`ENFORCE_SUMMARY_WINDOW` in `backend/src/journalSummaries/summaryWindow.js` is **`false`** while developing so creation can be tested any day. Set it to `true` before shipping the Sunday ritual.
 
 ## 14. Success criteria
 

--- a/docs/weekly-journal-summary.md
+++ b/docs/weekly-journal-summary.md
@@ -1,0 +1,275 @@
+# Weekly Journal Summary — Feature Design
+
+**Status:** Proposed (planning only — not implemented)  
+**Module:** Journaling (`/journal`)  
+**Product intent:** Turn saved writings into a weekly self-reflection ritual, not just storage.
+
+---
+
+## 1. Problem
+
+Users can write and store journal entries (including transcribed handwriting), but the app currently offers little reason to return to that material. Without a reflection loop, journaling risks feeling like a dump rather than a mirror.
+
+## 2. Goal (v1)
+
+Once per week, during a limited time window, a logged-in user can generate an AI-powered weekly reflection with three sections:
+
+1. **Weekly summary** — plain-language overview of what they wrote and the main topics.
+2. **Best quote** — one sentence (or short passage) from their own writing that deserves to be seen again.
+3. **Socratic prompt** — one question or piece of advice in a Socratic style that invites further thinking (not therapy, not diagnosis).
+
+## 3. User experience
+
+### Happy path
+
+1. User journals during the week (existing `/journal` flow).
+2. On **Sunday, 12:00–18:00** (local product timezone — see open decisions), the app surfaces an alert/CTA: *“Tu resumen semanal está disponible.”*
+3. User opens `/journal/summary`.
+4. If no summary exists for the current week yet:
+   - Page shows a create CTA.
+   - User clicks → loading screen (reuse Thoughts Test loading pattern) while the backend generates.
+   - Results render in three sections on the same page.
+5. If a summary already exists for that week:
+   - Page shows the stored result (no re-generation in v1).
+
+### Outside the window
+
+- `/journal/summary` remains reachable (or optionally linked from history), but:
+  - No “available for creation” alert.
+  - Create button disabled / replaced with copy explaining next window.
+  - If a prior summary exists, user can still **read** it (recommended — otherwise missing Sunday loses the value).
+
+### Empty / edge cases
+
+| Case | Behavior |
+|---|---|
+| Not logged in | Same pattern as journal history: prompt login |
+| Zero entries in the week | Do not call the model; show empty state asking them to write first |
+| Very few / very short entries | Still allow generation; prompt should ask model to be honest about sparse material |
+| Generation fails / timeout | Loading ends with error toast + retry (if still inside window and no row stored) |
+| User deletes an entry after summary | Summary stays as a snapshot of that week (do not invalidate) |
+
+## 4. Scope boundaries (v1)
+
+**In scope**
+- On-demand generation (user click), not a background cron
+- Persist one summary per user per week
+- Three structured outputs from the model
+- Availability window for *creation*
+- Journal-module page + in-app CTA during the window
+- Auth-required API under existing `/auth/me/...` patterns
+
+**Out of scope (later)**
+- Push/email reminders that the window is open
+- Regenerating or editing summaries
+- Multi-week archive UI / comparison across weeks
+- Paid-role gating (journal is auth-only today; keep that unless product decides otherwise)
+- Including Thoughts Test `localStorage` journals (they are not in Postgres)
+- Streaming tokens, async job queues, or webhooks
+- Clinical language, mood scores, or “diagnosis-like” framing
+
+## 5. Architecture (fits current stack)
+
+Stack today: React/Vite frontend, Express backend on Vercel (`maxDuration: 20`), Postgres via `pg`, Hugging Face `InferenceClient` for LLM/vision, JWT cookie auth.
+
+```
+[Journal pages]
+    │ CTA when window open
+    ▼
+[/journal/summary]
+    │ GET availability + existing summary
+    │ POST generate (once)
+    ▼
+[auth routes + requireAuth]
+    │
+    ├─ list week entries (date-range query on journal_entries)
+    ├─ enforce Sunday window (server)
+    ├─ enforce uniqueness (one summary / user / week)
+    └─ HF chatCompletion → parse JSON → persist → return
+```
+
+### Why on-demand (not cron)
+
+- No job runner / Vercel cron exists today.
+- Generation only when the user is present matches the ritual UX and avoids paying for unused summaries.
+- Server still enforces the time window and uniqueness so the client cannot bypass limits.
+
+### Timeout risk
+
+Backend Vercel `maxDuration` is **20s**. Mitigation for v1:
+
+- Cap total input characters (e.g. newest-first truncate to ~8–12k chars).
+- Prefer **one** model call that returns all three sections as structured JSON (one round-trip).
+- Keep output short (summary paragraphs + one quote + one Socratic item).
+- If timeouts appear in practice, revisit: faster/smaller model, raise `maxDuration`, or async generation.
+
+## 6. Data model
+
+New migration: `backend/src/db/migrations/004_journal_weekly_summaries.sql`
+
+```sql
+CREATE TABLE journal_weekly_summaries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  week_start DATE NOT NULL,          -- Monday of the ISO week (product timezone date)
+  week_end DATE NOT NULL,            -- Sunday of that week
+  period_start TIMESTAMPTZ NOT NULL, -- inclusive UTC instant used for entry query
+  period_end TIMESTAMPTZ NOT NULL,   -- exclusive UTC instant
+  summary_text TEXT NOT NULL,
+  main_topics TEXT[] NOT NULL DEFAULT '{}',
+  best_quote TEXT NOT NULL,
+  best_quote_entry_id UUID REFERENCES journal_entries(id) ON DELETE SET NULL,
+  socratic_text TEXT NOT NULL,
+  entry_count INTEGER NOT NULL,
+  model_id TEXT,                     -- which HF model produced this
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, week_start)
+);
+
+CREATE INDEX journal_weekly_summaries_user_created_idx
+  ON journal_weekly_summaries (user_id, created_at DESC);
+```
+
+Also extend entry listing with a date-range helper (no schema change needed on `journal_entries`; `created_at` is already indexed).
+
+**Invariant:** At most one summary row per `(user_id, week_start)`. Creation outside the window is rejected by the API even if the unique constraint would allow a late write.
+
+## 7. API shape
+
+Mount next to existing journal routes in `backend/src/auth/auth.routes.js`.
+
+### `GET /auth/me/journal-summaries/current`
+
+Returns window + week metadata + summary if present.
+
+```json
+{
+  "weekStart": "2026-07-27",
+  "weekEnd": "2026-08-02",
+  "window": {
+    "timezone": "Europe/Madrid",
+    "open": true,
+    "opensAt": "2026-08-02T10:00:00.000Z",
+    "closesAt": "2026-08-02T16:00:00.000Z"
+  },
+  "entryCount": 5,
+  "canCreate": true,
+  "summary": null
+}
+```
+
+`canCreate` = authenticated + window open + no existing summary + `entryCount > 0`.
+
+### `POST /auth/me/journal-summaries/current`
+
+- Requires auth
+- Server recomputes week + window (never trust client clock alone for authorization)
+- Loads entries in `[period_start, period_end)`
+- Calls model, validates JSON, inserts row
+- Returns the created summary
+- Conflicts: `409` if already exists; `403` if outside window; `422` if no entries
+
+### Optional later
+
+`GET /auth/me/journal-summaries` — history list (out of scope for v1 UI, schema already supports it).
+
+## 8. AI design
+
+### Reuse
+
+- `InferenceClient` + `HF_TOKEN` (same as onboarding / transcription)
+- Output cleanup helpers like `normalizeLlmOutput.js` where useful
+- New prompt module, e.g. `backend/src/journalSummaries/prompts.js`
+
+### Single structured completion
+
+Ask the model for JSON only:
+
+```json
+{
+  "summary": "...",
+  "mainTopics": ["...", "..."],
+  "bestQuote": "...",
+  "socratic": "..."
+}
+```
+
+Prompt responsibilities:
+
+| Section | Instruction sketch |
+|---|---|
+| Summary | Neutral mirror of themes; use user’s language (Spanish); no clinical labels |
+| Main topics | 2–5 short labels; may align with existing chips (`Trabajo`, `Interpersonal`, …) but can be freer |
+| Best quote | Must be a **verbatim or near-verbatim** excerpt from the provided entries; never invent |
+| Socratic | One open question or gentle challenge; Socratic method; no lectures, no “you should”, no diagnosis |
+
+Also pass entry ids + timestamps so the backend can optionally attach `best_quote_entry_id` by matching the quote substring; if no match, store quote text and leave FK null.
+
+### Safety / product voice
+
+- Frame as self-reflection companion, not a therapist.
+- If content suggests crisis, prefer a short redirect-to-help style refusal for the Socratic section only (keep summary factual) — exact copy TBD with product.
+- Never invent diary events that were not in the source text.
+
+## 9. Frontend plan
+
+| Piece | Approach |
+|---|---|
+| Route | `/journal/summary` in `App.jsx` beside existing journal routes |
+| Page | `frontend/src/Pages/Journal/JournalSummary.jsx` (+ CSS in `Journal.css` or sibling) |
+| Loading | Adapt `TestLoadingScreen` pattern: progress + reflective quote, but `onDone` waits for **real** `POST` (or `Promise.all` of min display time + request) |
+| CTA / alert | Banner on `/journal` and/or `/journal/history` when `window.open && canCreate`; optionally subtle nav hint |
+| Result layout | Three stacked sections (not a dashboard of cards): Summary → Best quote → Socratic prompt |
+| History link | From journal header area: “Resumen” next to “Escribir” / history patterns |
+
+Guest / auth behavior should match `JournalHistory.jsx`.
+
+## 10. Availability window
+
+Proposed defaults (confirm before coding):
+
+- **Timezone:** `Europe/Madrid` (product is Spanish-first)
+- **Day:** Sunday
+- **Hours:** 12:00–18:00 inclusive start, exclusive end
+- **Week contents:** Monday 00:00 → Sunday 24:00 in that timezone (ISO week), i.e. the week that just concluded when Sunday’s window opens
+
+Implementation detail: pure functions in a small shared-style module on the **server** (`getCurrentWeekBounds`, `isSummaryWindowOpen`). Frontend may duplicate display helpers but must not be the authority.
+
+Closest existing pattern: client date gate in `promoConfig.js` / `PromoGate` — reuse the *idea*, not the promo code path. Enforcement for creation must be server-side.
+
+## 11. Suggested implementation slices
+
+Build in thin vertical slices; each slice shippable alone.
+
+1. **Window + status API** — `GET current` with `open` / `entryCount` / `canCreate`; no LLM yet.
+2. **Summary page shell + CTA banner** — wired to GET; empty / closed / ready states.
+3. **Persistence + POST without LLM** — stubbed summary text for local/dev to prove uniqueness + UX.
+4. **Real LLM generation** — prompt, parse, store, loading screen tied to request.
+5. **Polish** — copy, error/retry, quote attribution, basic tests.
+
+## 12. Testing plan
+
+- Unit: week bounds + window open/closed around DST edges (`Europe/Madrid`).
+- Unit: prompt input truncation / JSON parse failure handling.
+- API: create once → second create 409; outside window 403; zero entries 422.
+- Frontend: states for closed / ready / loading / result / error (Vitest patterns like `Journal.test.jsx`).
+- Manual: generate with a week of mixed-topic entries; verify quote appears in source text.
+
+## 13. Open decisions (need product confirmation)
+
+1. **Exact window** — Sunday 12:00–18:00 Europe/Madrid, or another schedule?
+2. **Missed window** — Can users create late (e.g. until Monday), or strictly Sunday only? Can they still *read* last week’s summary anytime?
+3. **Regeneration** — Forbidden in v1 (recommended), or allow one retry on failure only?
+4. **Minimum entries** — Any entry (`count >= 1`) vs require N entries / N characters?
+5. **Access** — All authenticated users (consistent with journal today) vs `paid` only?
+6. **Best quote strictness** — Must match an entry substring exactly, or allow light cleanup (punctuation/ellipsis)?
+7. **Copy language** — Spanish-only prompts/UI for v1?
+8. **Socratic tone** — Warm mentor vs sharper classic Socrates? Any topics the prompt must avoid?
+
+## 14. Success criteria
+
+- Users who write during the week have a clear Sunday ritual that returns value from their own words.
+- Summary feels personal (topics + quote from *their* text), not generic wellness filler.
+- Socratic section produces a question the user could actually journal about next.
+- Creation cannot be spammed (one per week; window enforced server-side).
+- Experience stays within the 20s serverless budget for typical weekly volume.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import PromoGate from './Pages/Promo/PromoGate.jsx';
 import Tests from './Pages/Tests/Tests.jsx';
 import Journal from './Pages/Journal/Journal.jsx';
 import JournalHistory from './Pages/Journal/JournalHistory.jsx';
+import JournalSummary from './Pages/Journal/JournalSummary.jsx';
 import ScrollToTop from './Components/ScrollToTop/ScrollToTop.jsx';
 
 function App() {
@@ -47,6 +48,7 @@ function App() {
                             <Route path='tests' element={<Tests />} />
                             <Route path='test/:testId' element={<ThoughtsTest />} />
                             <Route path='journal/history' element={<JournalHistory />} />
+                            <Route path='journal/summary' element={<JournalSummary />} />
                             <Route path='journal' element={<Journal />} />
                             <Route path='session/:sessionId' element={<Session />} />
                         </Route>

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -452,6 +452,103 @@
   cursor: pointer;
 }
 
+.journal-summary-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 14px 16px;
+  margin-bottom: 8px;
+  border: 1.5px solid var(--accent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 8%, #fff);
+}
+
+.journal-summary-banner__text {
+  margin: 0;
+  line-height: 1.45;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.journal-summary-banner__link {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.journal-summary-banner__link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.journal-summary__week {
+  margin: -8px 0 0;
+  color: var(--muted, #6b7280);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.journal-summary__create {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 24px;
+}
+
+.journal-summary__lead {
+  margin: 0;
+  line-height: 1.5;
+  text-align: center;
+  color: var(--text);
+}
+
+.journal-summary__result {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.journal-summary__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.journal-summary__heading {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--accent);
+}
+
+.journal-summary__body,
+.journal-summary__socratic {
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  color: var(--text);
+}
+
+.journal-summary__quote {
+  margin: 0;
+  padding: 0 0 0 16px;
+  border-left: 3px solid var(--accent);
+  font-size: 1.1rem;
+  font-style: italic;
+  line-height: 1.55;
+  color: var(--text);
+}
+
+.journal-summary__nav-links {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: auto;
+  padding-top: 24px;
+}
+
 @media (min-width: 1000px) {
   .journal-guest-modal {
     max-width: 500px;

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -10,6 +10,7 @@ import {
   prepareImageForUpload,
   MAX_UPLOAD_BYTES,
 } from './journalImage.js';
+import JournalSummaryBanner from './JournalSummaryBanner.jsx';
 import './Journal.css';
 
 const JOURNAL_TOPICS = [
@@ -180,6 +181,7 @@ const Journal = () => {
     <div className="journal-page">
       <Navigation />
       <main className="journal-page__main">
+        <JournalSummaryBanner />
         <h1 className="journal-page__prompt">¿Qué tienes en mente?</h1>
 
         <div className="journal-page__composer">
@@ -287,6 +289,9 @@ const Journal = () => {
           </button>
           <Link to="/journal/history" className="journal-page__history-link">
             Ver historial
+          </Link>
+          <Link to="/journal/summary" className="journal-page__history-link">
+            Resumen semanal
           </Link>
         </div>
       </main>

--- a/frontend/src/Pages/Journal/JournalHistory.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.jsx
@@ -5,6 +5,7 @@ import CloseIcon from '../../Components/CloseIcon/CloseIcon.jsx';
 import { useAuth } from '../../Context/AuthContext.jsx';
 import { apiFetch } from '../../api/client.js';
 import { emitToast } from '../../lib/toastBus.js';
+import JournalSummaryBanner from './JournalSummaryBanner.jsx';
 import './Journal.css';
 
 const EXCERPT_WORD_COUNT = 40;
@@ -138,6 +139,8 @@ const JournalHistory = () => {
           </Link>
         </header>
 
+        <JournalSummaryBanner />
+
         {status === 'loading' && (
           <p className="journal-history__status">Cargando…</p>
         )}
@@ -248,12 +251,20 @@ const JournalHistory = () => {
         )}
 
         {status !== 'loading' && (
-          <Link
-            to="/journal"
-            className="journal-history__write-button journal-history__write-button--footer"
-          >
-            ESCRIBIR
-          </Link>
+          <>
+            <Link
+              to="/journal/summary"
+              className="journal-page__history-link"
+            >
+              Resumen semanal
+            </Link>
+            <Link
+              to="/journal"
+              className="journal-history__write-button journal-history__write-button--footer"
+            >
+              ESCRIBIR
+            </Link>
+          </>
         )}
       </main>
 

--- a/frontend/src/Pages/Journal/JournalSummary.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.jsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Navigation from '../../Components/Navigation/Navigation.jsx';
+import { useAuth } from '../../Context/AuthContext.jsx';
+import { apiFetch } from '../../api/client.js';
+import { emitToast } from '../../lib/toastBus.js';
+import JournalSummaryLoadingScreen from './JournalSummaryLoadingScreen.jsx';
+import './Journal.css';
+
+const formatWeekLabel = (weekStart, weekEnd) => {
+  if (!weekStart || !weekEnd) return '';
+  const start = new Date(`${weekStart}T12:00:00`);
+  const end = new Date(`${weekEnd}T12:00:00`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return `${weekStart} – ${weekEnd}`;
+  }
+  const fmt = new Intl.DateTimeFormat('es-ES', {
+    day: 'numeric',
+    month: 'long',
+  });
+  return `${fmt.format(start)} – ${fmt.format(end)}`;
+};
+
+const JournalSummary = () => {
+  const { user, status } = useAuth();
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [generateReady, setGenerateReady] = useState(false);
+  const [pendingSummary, setPendingSummary] = useState(null);
+
+  const loadCurrent = useCallback(async () => {
+    if (status !== 'ready' || !user) {
+      setPayload(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await apiFetch('/auth/me/journal-summaries/current');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || 'No se pudo cargar el resumen.');
+      }
+      setPayload(data);
+    } catch (err) {
+      console.error('[journal-summaries GET]', err);
+      setPayload(null);
+      emitToast(err.message || 'No se pudo cargar el resumen.');
+    } finally {
+      setLoading(false);
+    }
+  }, [status, user]);
+
+  useEffect(() => {
+    loadCurrent();
+  }, [loadCurrent]);
+
+  const handleCreate = async () => {
+    if (generating || !payload?.canCreate) return;
+
+    setGenerating(true);
+    setGenerateReady(false);
+    setPendingSummary(null);
+
+    try {
+      const res = await apiFetch('/auth/me/journal-summaries/current', {
+        method: 'POST',
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || 'No se pudo crear el resumen.');
+      }
+      setPendingSummary(data.summary ?? null);
+      setGenerateReady(true);
+    } catch (err) {
+      console.error('[journal-summaries POST]', err);
+      setGenerating(false);
+      setGenerateReady(false);
+      setPendingSummary(null);
+      emitToast(err.message || 'No se pudo crear el resumen.');
+      // Refresh so canCreate / existing summary stay accurate after a race.
+      loadCurrent();
+    }
+  };
+
+  const finishLoadingScreen = useCallback(() => {
+    if (pendingSummary) {
+      setPayload((prev) =>
+        prev
+          ? {
+              ...prev,
+              summary: pendingSummary,
+              canCreate: false,
+            }
+          : prev,
+      );
+    }
+    setGenerating(false);
+    setGenerateReady(false);
+    setPendingSummary(null);
+  }, [pendingSummary]);
+
+  if (generating) {
+    return (
+      <div className="journal-page journal-page--summary">
+        <Navigation />
+        <JournalSummaryLoadingScreen
+          ready={generateReady}
+          onDone={finishLoadingScreen}
+        />
+      </div>
+    );
+  }
+
+  const summary = payload?.summary;
+  const weekLabel = formatWeekLabel(payload?.weekStart, payload?.weekEnd);
+
+  return (
+    <div className="journal-page journal-page--summary">
+      <Navigation />
+      <main className="journal-page__main journal-page__main--history">
+        <header className="journal-history__header">
+          <h1 className="journal-history__title">Resumen semanal</h1>
+          <Link
+            to="/journal"
+            className="journal-history__write-button journal-history__write-button--header"
+          >
+            Escribir
+          </Link>
+        </header>
+
+        {weekLabel && (
+          <p className="journal-summary__week">{weekLabel}</p>
+        )}
+
+        {status === 'loading' && (
+          <p className="journal-history__status">Cargando…</p>
+        )}
+
+        {status === 'ready' && !user && (
+          <div className="journal-history__empty">
+            <p>Inicia sesión para ver o crear tu resumen semanal.</p>
+            <Link to="/login" className="journal-history__action-link">
+              Iniciar sesión
+            </Link>
+          </div>
+        )}
+
+        {status === 'ready' && user && loading && (
+          <p className="journal-history__status">Cargando resumen…</p>
+        )}
+
+        {status === 'ready' && user && !loading && summary && (
+          <div className="journal-summary__result">
+            <section className="journal-summary__section">
+              <h2 className="journal-summary__heading">Esta semana</h2>
+              {Array.isArray(summary.mainTopics) &&
+                summary.mainTopics.length > 0 && (
+                  <ul
+                    className="journal-history__topics"
+                    aria-label="Temas principales"
+                  >
+                    {summary.mainTopics.map((topic) => (
+                      <li key={topic} className="journal-history__topic-chip">
+                        {topic}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              <p className="journal-summary__body">{summary.summaryText}</p>
+            </section>
+
+            <section className="journal-summary__section">
+              <h2 className="journal-summary__heading">La frase que destacó</h2>
+              <blockquote className="journal-summary__quote">
+                {summary.bestQuote}
+              </blockquote>
+            </section>
+
+            <section className="journal-summary__section">
+              <h2 className="journal-summary__heading">Pregunta de Sócrates</h2>
+              <p className="journal-summary__socratic">{summary.socraticText}</p>
+            </section>
+          </div>
+        )}
+
+        {status === 'ready' && user && !loading && !summary && (
+          <div className="journal-summary__create">
+            {payload?.canCreate ? (
+              <>
+                <p className="journal-summary__lead">
+                  Ya puedes crear el resumen de esta semana a partir de tus
+                  escrituras.
+                </p>
+                <button
+                  type="button"
+                  className="journal-page__complete-button"
+                  onClick={handleCreate}
+                >
+                  CREAR RESUMEN
+                </button>
+              </>
+            ) : (
+              <div className="journal-history__empty">
+                {(payload?.entryCount ?? 0) < (payload?.minEntries ?? 2) ? (
+                  <>
+                    <p>
+                      Necesitas al menos {payload?.minEntries ?? 2} entradas
+                      esta semana para crear el resumen. Llevas{' '}
+                      {payload?.entryCount ?? 0}.
+                    </p>
+                    <Link to="/journal" className="journal-history__action-link">
+                      Escribir
+                    </Link>
+                  </>
+                ) : payload?.window?.enforced && !payload?.window?.open ? (
+                  <p>
+                    El resumen se puede crear el domingo de 12:00 a 18:00 (hora
+                    de Madrid). Mientras tanto, sigue escribiendo.
+                  </p>
+                ) : (
+                  <p>El resumen de esta semana no está disponible ahora.</p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="journal-summary__nav-links">
+          <Link to="/journal/history" className="journal-page__history-link">
+            Ver historial
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default JournalSummary;

--- a/frontend/src/Pages/Journal/JournalSummary.test.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.test.jsx
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import JournalSummary from './JournalSummary.jsx';
+import { apiFetch } from '../../api/client.js';
+
+const mockUseAuth = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock('../../Context/AuthContext.jsx', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('../../Components/Navigation/Navigation.jsx', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../api/client.js', () => ({ apiFetch: vi.fn() }));
+vi.mock('../../lib/toastBus.js', () => ({ emitToast: vi.fn() }));
+
+describe('JournalSummary page states', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    apiFetch.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('prompts guests to log in', () => {
+    mockUseAuth.mockReturnValue({ user: null, status: 'ready' });
+    render(<JournalSummary />);
+    expect(
+      screen.getByText(/Inicia sesión para ver o crear tu resumen semanal/i),
+    ).toBeTruthy();
+  });
+
+  test('shows create CTA when canCreate is true', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u1' }, status: 'ready' });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        weekStart: '2026-07-27',
+        weekEnd: '2026-08-02',
+        window: { open: true, enforced: false },
+        entryCount: 3,
+        minEntries: 2,
+        canCreate: true,
+        summary: null,
+      }),
+    });
+
+    render(<JournalSummary />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /CREAR RESUMEN/i }),
+      ).toBeTruthy();
+    });
+  });
+
+  test('renders stored summary sections', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u1' }, status: 'ready' });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        weekStart: '2026-07-27',
+        weekEnd: '2026-08-02',
+        window: { open: true, enforced: false },
+        entryCount: 3,
+        minEntries: 2,
+        canCreate: false,
+        summary: {
+          summaryText: 'Escribiste sobre el trabajo y la duda.',
+          mainTopics: ['Trabajo'],
+          bestQuote: 'Nunca es suficiente',
+          socraticText: '¿Qué prueba tienes de eso?',
+        },
+      }),
+    });
+
+    render(<JournalSummary />);
+    await waitFor(() => {
+      expect(screen.getByText(/Escribiste sobre el trabajo/i)).toBeTruthy();
+      expect(screen.getByText(/Nunca es suficiente/i)).toBeTruthy();
+      expect(screen.getByText(/Qué prueba tienes/i)).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/Pages/Journal/JournalSummaryBanner.jsx
+++ b/frontend/src/Pages/Journal/JournalSummaryBanner.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../Context/AuthContext.jsx';
+import { apiFetch } from '../../api/client.js';
+
+/**
+ * Soft alert when the weekly summary can be created.
+ * Hidden for guests, while loading, or when creation is not available.
+ */
+const JournalSummaryBanner = () => {
+  const { user, status } = useAuth();
+  const [canCreate, setCanCreate] = useState(false);
+
+  useEffect(() => {
+    if (status !== 'ready' || !user) {
+      setCanCreate(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await apiFetch('/auth/me/journal-summaries/current');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setCanCreate(Boolean(data.canCreate));
+      } catch {
+        if (!cancelled) setCanCreate(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [status, user]);
+
+  if (!canCreate) return null;
+
+  return (
+    <div className="journal-summary-banner" role="status">
+      <p className="journal-summary-banner__text">
+        Tu resumen semanal está disponible para crearse.
+      </p>
+      <Link to="/journal/summary" className="journal-summary-banner__link">
+        Ir al resumen
+      </Link>
+    </div>
+  );
+};
+
+export default JournalSummaryBanner;

--- a/frontend/src/Pages/Journal/JournalSummaryLoadingScreen.jsx
+++ b/frontend/src/Pages/Journal/JournalSummaryLoadingScreen.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { getRandomSummaryLoadingQuote } from './summaryLoadingQuotes.js';
+import '../ThoughtsTest/TestLoadingScreen.css';
+
+// Visual floor so the bar feels intentional even if the API is fast.
+const MIN_DISPLAY_MS = 5000;
+
+const JournalSummaryLoadingScreen = ({ ready = false, onDone }) => {
+  const [full, setFull] = useState(false);
+  const [percent, setPercent] = useState(0);
+  const [minElapsed, setMinElapsed] = useState(false);
+  const [quote] = useState(getRandomSummaryLoadingQuote);
+
+  useEffect(() => {
+    const start = performance.now();
+    const frame = requestAnimationFrame(() => setFull(true));
+
+    const tick = () => {
+      const elapsed = performance.now() - start;
+      const value = Math.min(100, Math.round((elapsed / MIN_DISPLAY_MS) * 100));
+      setPercent(value);
+      if (value < 100) {
+        interval = requestAnimationFrame(tick);
+      }
+    };
+    let interval = requestAnimationFrame(tick);
+
+    const timer = setTimeout(() => setMinElapsed(true), MIN_DISPLAY_MS);
+    return () => {
+      cancelAnimationFrame(frame);
+      cancelAnimationFrame(interval);
+      clearTimeout(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (ready && minElapsed) onDone?.();
+  }, [ready, minElapsed, onDone]);
+
+  return (
+    <div className="test-loading-screen">
+      <p className="test-loading-screen__text">
+        Preparando tu resumen... [{percent}%]
+      </p>
+      <div
+        className="test-loading-screen__bar"
+        role="progressbar"
+        aria-label="Preparando resumen semanal"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className={
+            'test-loading-screen__bar-fill' +
+            (full ? ' test-loading-screen__bar-fill--full' : '')
+          }
+          style={{ transitionDuration: `${MIN_DISPLAY_MS}ms` }}
+        />
+      </div>
+      <p className="test-loading-screen__quote">{quote}</p>
+    </div>
+  );
+};
+
+export default JournalSummaryLoadingScreen;

--- a/frontend/src/Pages/Journal/summaryLoadingQuotes.js
+++ b/frontend/src/Pages/Journal/summaryLoadingQuotes.js
@@ -1,0 +1,12 @@
+export const summaryLoadingQuotes = [
+  'Una vida sin examinar no merece ser vivida.\n\n- Sócrates.',
+  'Conócete a ti mismo.\n\n- Inscripción del templo de Apolo en Delfos.',
+  'Estamos leyendo tu semana con calma…',
+  'Lo que escribiste merece ser visto otra vez.',
+  'La pregunta correcta a veces vale más que la respuesta.',
+];
+
+export const getRandomSummaryLoadingQuote = () =>
+  summaryLoadingQuotes[
+    Math.floor(Math.random() * summaryLoadingQuotes.length)
+  ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the weekly AI journal reflection planned in `docs/weekly-journal-summary.md`.

Users with **≥2 entries** in the current Europe/Madrid week can open `/journal/summary`, generate once, and see:
1. Weekly overview + topics
2. Best quote from their own writing
3. A sharp Socratic prompt

### Local testing

Branch: **`cursor/weekly-journal-summary-plan-6a18`**

```bash
git fetch origin
git checkout cursor/weekly-journal-summary-plan-6a18
```

Apply migration `004_journal_weekly_summaries.sql`, start backend + frontend (`HF_TOKEN` required).

**Sunday window bypassed** via `ENFORCE_SUMMARY_WINDOW = false` in `summaryWindow.js` for local testing.

### Recent prompt tweak

- System/user prompts are now **English** (output fields still Spanish for the product).
- Summary must address the user in **second person** (`tú` / “Has estado pensando…”, not “el autor del diario”).
- Engineering principles now include an **English codebase** language rule.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbc6a-3c6c-7c02-8acc-0c4ef0866a18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbc6a-3c6c-7c02-8acc-0c4ef0866a18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

