### PR TITLE
Update repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # 🧠 Detox Mental
 
 Detox Mental is a guided self-reflection web app designed to help users confront and reframe destructive thought patterns.
-It combines long-form educational content, an unlockable 15-session course, 15 journaling exercises, and authentication to preserve user progress.
+It combines long-form educational content, an unlockable 15-session course with guided exercises, free-form journaling (including handwriting transcription and entry history), AI-assisted onboarding, and authentication to preserve user progress.
 
 ## 🚀 Overview
 
 This repository is a monorepo with:
 
-- `frontend/` - React + Vite SPA (article, course, onboarding, account, instructions)
-- `backend/` - Express API (auth, session unlock persistence, chat)
+- `frontend/` - React + Vite SPA (article, course, onboarding, journal, account, payments, instructions)
+- `backend/` - Express API (auth, session unlock persistence, chat, Stripe, journal entries and transcription)
 
 Core product experience includes:
 
 - Main article introducing the Detox Mental framework
-- 15-session audio/writing course
+- 15-session audio/writing course with guided exercises
 - Session unlock flow with persisted unlocked sessions per user
+- Free-form journal with entry history and handwriting-to-text from uploaded images
+- AI-powered onboarding chat
 - Passwordless authentication via magic links
+- Stripe Checkout for course membership
 
 ## 🛠️ Tech Stack
 
@@ -24,6 +27,8 @@ Core product experience includes:
 - **Database:** PostgreSQL
 - **Auth:** Magic links + JWT in HTTP-only cookies
 - **Email:** Resend
+- **Payments:** Stripe
+- **AI:** Hugging Face Inference (onboarding chat and journal image transcription)
 - **Deployment:** Vercel (frontend and backend as separate projects)
 
 ## Repository Structure
@@ -36,9 +41,11 @@ Core product experience includes:
 ├─ backend/
 │  ├─ src/
 │  └─ api/
+├─ docs/
 ├─ ROADMAP.md
 ├─ AUTH_ARCHITECTURE.md
-└─ DECISIONS.md
+├─ DECISIONS.md
+└─ ENV_SETUP.md
 ```
 
 ## Local Development
@@ -66,6 +73,8 @@ Set local env files at minimum:
   - `API_PUBLIC_URL=http://localhost:3000`
 - `frontend/.env.local`
   - `VITE_API_URL=http://localhost:3000`
+
+For Stripe, Hugging Face, and the full variable matrix, see [ENV_SETUP.md](./ENV_SETUP.md).
 
 ### 3) Run both apps
 
@@ -96,6 +105,8 @@ Frontend usually runs on `http://localhost:5173`.
 npm run dev
 npm run build
 npm run preview
+npm run lint
+npm run test
 ```
 
 ### Backend
@@ -103,6 +114,8 @@ npm run preview
 ```bash
 npm run dev
 npm run start
+npm run lint
+npm run test
 ```
 
 ## Documentation
@@ -111,6 +124,7 @@ npm run start
 - [AUTH_ARCHITECTURE.md](./AUTH_ARCHITECTURE.md) - auth design and decisions
 - [DECISIONS.md](./DECISIONS.md) - architectural/product decisions log
 - [ENV_SETUP.md](./ENV_SETUP.md) - environment setup notes
+- [docs/harness.md](./docs/harness.md) - feature validation checklist before commit
 
 ## 🤝 Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,6 @@
 🧭 Roadmap
 
-Detox Mental evolves in phases that mirror its own philosophy — awareness first, then dialogue, then integration.
-
-Each major version marks a conceptual shift, not just a technical one.
+Detox Mental grows through discrete product milestones. Each major version expands what the app can do—from static educational content into interactive practice, identity, monetization, and personal journaling tools.
 
 ### v1.0 — The Core MVP
 
@@ -40,18 +38,24 @@ State: ✅ Released on May 9th, 2026.
 Stripe integration and membership options.
 The project evolves from a self-contained prototype into a sustainable product.
 
-### Next — Weekly Journal Summary (self-reflection ritual)
+### v4.0 — Journaling Module
 
-State: 🚧 V1 implemented on branch (Sunday window bypassed for local testing). See `docs/weekly-journal-summary.md`.
+State: ✅ Released on July 25th, 2026.
+
+Free-form journaling with a dedicated writing interface and entry history.
+Includes handwriting transcription from uploaded images—turning paper notes into editable entries—and makes Detox Mental a place to keep a living record of one’s thinking, not only to consume course content.
+
+### Weekly Journal Summary (self-reflection ritual)
+
+State: ✅ V1 released. See `docs/weekly-journal-summary.md`.
 
 Turns stored journal entries into a Sunday-only AI reflection: weekly topic summary, a “best quote” from the user’s own writing, and a Socratic prompt. Generated on demand during a limited time window; persisted once per week.
 
 ### Future Product Directions
 
 - Full translation of the app into English, opening Detox Mental to broader English-speaking markets.
-- Onboarding optimization focused on retention: clearer value communication, stronger expectation-setting, and extended educational information about the core principles and benefits of the product.
-- Implementation of the Detox Mental Lab: a thought-based, AI-powered exercise database that personalizes recommendations according to each user's recurring thought patterns.
-- A full editorial and product positioning revamp to move from the language of "tormenting thoughts" toward stress relief, emotional regulation, and when appropriate, referral to a mental health professional.
+- Topic classification for journal entries, as a foundation for later insight extraction from recurring themes.
+- AI character chats for reflecting on one’s thoughts—e.g. a Socrates that answers only with Socratic questions, and a Machiavelli that pushes toward clear-eyed, practical self-interest.
 
 ### Vision:
 Detox Mental is not just a mental health tool. It’s an ongoing experiment in self-observation and human–machine dialogue — how technology can mirror our thinking rather than distract from it.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -34,6 +34,13 @@ export default [
     },
   },
   {
+    files: ['**/Context/**/*.{js,jsx}'],
+    rules: {
+      // Providers intentionally co-export hooks/context for a single import surface.
+      'react-refresh/only-export-components': 'off',
+    },
+  },
+  {
     files: ['**/*.test.{js,jsx}'],
     languageOptions: {
       globals: { ...globals.node, ...globals.jest, vi: 'readonly' },

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,6 @@
 </head>
 <body>
     <div id="root"></div>
-    <script type="module" src="./src/App.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
 </body>
 </html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import ReactDOM from 'react-dom/client';
 import AuthProvider from './Context/AuthContext.jsx';
 import SessionsProvider from './Context/SessionsContext.jsx';
 import ArticleWrapper from './Pages/Article/ArticleWrapper.jsx';
@@ -23,7 +22,7 @@ import JournalHistory from './Pages/Journal/JournalHistory.jsx';
 import JournalSummary from './Pages/Journal/JournalSummary.jsx';
 import ScrollToTop from './Components/ScrollToTop/ScrollToTop.jsx';
 
-function App() {
+const App = () => {
     return (
         <React.StrictMode>
             <BrowserRouter>
@@ -60,5 +59,4 @@ function App() {
     )
 }
 
-const rootElement = document.getElementById('root');
-ReactDOM.createRoot(rootElement).render(<App />);
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,5 @@
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+const rootElement = document.getElementById('root');
+ReactDOM.createRoot(rootElement).render(<App />);


### PR DESCRIPTION
## Summary

Documents the v4.0 journaling milestone and clears persistent frontend harness lint noise so validation stays clean after feature work.

## Changes

### Docs
- Refresh `README.md` for the current product surface (journal, transcription, Stripe, Hugging Face, lint/test scripts, env/harness links).
- Update `ROADMAP.md` with a professional intro, completed `v4.0 — Journaling Module`, retained Weekly Journal Summary, and revised future directions (English translation, topic classification, AI character chats).

### Frontend / harness
- Split the Vite entrypoint into `main.jsx` so `App.jsx` only exports the app component.
- Turn off `react-refresh/only-export-components` for `Context/` files where providers intentionally co-export hooks.

## Notes
- Local annotated tag `V4.0` was created on this branch; push it separately after merge if you want it on GitHub.
- This PR does not include the journaling feature implementation itself (already on `main`); it documents and polishes around that milestone.

## Test plan
- [ ] `cd frontend && npm run lint` — 0 problems
- [ ] `cd frontend && npm run test && npm run build`
- [ ] `cd backend && npm run lint && npm run test`
- [ ] Smoke-check the app still boots (`frontend` + `backend` `npm run dev`)