### PR TITLE
Update interface

### DIFF
--- a/frontend/public/icons/chevron-up.svg
+++ b/frontend/public/icons/chevron-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#F4F2F0"><path d="M480-528 296-344l-56-56 240-240 240 240-56 56-184-184Z"/></svg>

--- a/frontend/src/Components/Navigation/Navigation.css
+++ b/frontend/src/Components/Navigation/Navigation.css
@@ -20,6 +20,38 @@
     transform: translateY(0);
 }
 
+.navigation__reveal {
+    position: fixed;
+    left: 12px;
+    bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+    z-index: 19;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: var(--accent);
+    opacity: 0.85;
+    cursor: pointer;
+}
+
+.navigation__reveal:hover {
+    opacity: 1;
+}
+
+.navigation__reveal:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.navigation__reveal-icon {
+    width: 22px;
+    height: 22px;
+}
+
 .navigation__section {
     flex: 1;
     min-height: 51px;
@@ -162,6 +194,10 @@
     .navigation {
         max-width: 700px;
         margin: 0 auto;
+    }
+
+    .navigation__reveal {
+        left: max(12px, calc(50% - 350px + 12px));
     }
 
     .navigation__menu-overlay {

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -4,11 +4,14 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../Context/AuthContext.jsx';
 import { isPromoEnabled } from '../../data/promoConfig.js';
 
+const isVisibleByDefault = (pathname) =>
+    pathname === '/' || pathname.startsWith('/course');
+
 const Navigation = () => {
     const [menuState, setMenuState] = useState('closed');
-    const [isBarVisible, setIsBarVisible] = useState(true);
     const navigate = useNavigate();
     const location = useLocation();
+    const [isBarVisible, setIsBarVisible] = useState(() => isVisibleByDefault(location.pathname));
     const { user, status } = useAuth();
     const isCourseRoute = location.pathname.startsWith('/course') || location.pathname.startsWith('/session');
     const isTestsRoute = location.pathname.startsWith('/tests') || location.pathname.startsWith('/test');
@@ -52,13 +55,10 @@ const Navigation = () => {
         let lastY = window.scrollY;
         const onScroll = () => {
             const currentY = window.scrollY;
-            if (currentY < lastY - 200) {
-                setIsBarVisible(true);
-                lastY = currentY;
-            } else if (currentY > lastY + 6) {
+            if (currentY > lastY + 6) {
                 setIsBarVisible(false);
-                lastY = currentY;
             }
+            lastY = currentY;
         };
         window.addEventListener('scroll', onScroll, { passive: true });
         return () => window.removeEventListener('scroll', onScroll);
@@ -103,6 +103,21 @@ const Navigation = () => {
                         )}
                     </div>
                 </div>
+            )}
+            {!isBarVisible && (
+                <button
+                    type='button'
+                    className='navigation__reveal'
+                    onClick={() => setIsBarVisible(true)}
+                    aria-label='Mostrar navegación'
+                >
+                    <img
+                        className='navigation__reveal-icon'
+                        src='/icons/chevron-up.svg'
+                        alt=''
+                        aria-hidden='true'
+                    />
+                </button>
             )}
             <div className={`navigation${isBarVisible ? ' navigation--visible' : ''}`}>
                 <button type='button' className='navigation__section navigation__section--left' onClick={openMenu}>

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -21,6 +21,10 @@
   gap: 24px;
 }
 
+.journal-page--history .journal-page__main {
+  padding-top: 30px;
+}
+
 .journal-page__prompt {
   margin: 0 0 50px;
   padding-top: clamp(32px, 12svh, 80px);
@@ -270,6 +274,24 @@
   gap: 16px;
 }
 
+/* Two actions do not fit next to the title on narrow screens, so they move to
+   their own full-width row below it. */
+.journal-history__header--with-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.journal-history__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.journal-history__header--with-actions .journal-history__header-actions > * {
+  flex: 1 1 0;
+}
+
 .journal-history__title {
   margin: 0;
   font-size: 1.5rem;
@@ -296,6 +318,11 @@
   flex-shrink: 0;
   padding: 8px 16px;
   font-size: 15px;
+}
+
+.journal-history__write-button--secondary {
+  background: var(--background);
+  color: var(--accent);
 }
 
 .journal-history__write-button--footer {
@@ -547,6 +574,17 @@
   gap: 12px;
   margin-top: auto;
   padding-top: 24px;
+}
+
+@media (min-width: 600px) {
+  .journal-history__header--with-actions {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .journal-history__header--with-actions .journal-history__header-actions > * {
+    flex: 0 0 auto;
+  }
 }
 
 @media (min-width: 1000px) {

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -290,9 +290,6 @@ const Journal = () => {
           <Link to="/journal/history" className="journal-page__history-link">
             Ver historial
           </Link>
-          <Link to="/journal/summary" className="journal-page__history-link">
-            Resumen semanal
-          </Link>
         </div>
       </main>
 

--- a/frontend/src/Pages/Journal/JournalHistory.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.jsx
@@ -129,14 +129,22 @@ const JournalHistory = () => {
     <div className="journal-page journal-page--history">
       <Navigation />
       <main className="journal-page__main journal-page__main--history">
-        <header className="journal-history__header">
+        <header className="journal-history__header journal-history__header--with-actions">
           <h1 className="journal-history__title">Historial</h1>
-          <Link
-            to="/journal"
-            className="journal-history__write-button journal-history__write-button--header"
-          >
-            Escribir
-          </Link>
+          <div className="journal-history__header-actions">
+            <Link
+              to="/journal"
+              className="journal-history__write-button journal-history__write-button--header"
+            >
+              Escribir
+            </Link>
+            <Link
+              to="/journal/summary"
+              className="journal-history__write-button journal-history__write-button--header journal-history__write-button--secondary"
+            >
+              Resumen
+            </Link>
+          </div>
         </header>
 
         <JournalSummaryBanner />
@@ -251,20 +259,12 @@ const JournalHistory = () => {
         )}
 
         {status !== 'loading' && (
-          <>
-            <Link
-              to="/journal/summary"
-              className="journal-page__history-link"
-            >
-              Resumen semanal
-            </Link>
-            <Link
-              to="/journal"
-              className="journal-history__write-button journal-history__write-button--footer"
-            >
-              ESCRIBIR
-            </Link>
-          </>
+          <Link
+            to="/journal"
+            className="journal-history__write-button journal-history__write-button--footer"
+          >
+            ESCRIBIR
+          </Link>
         )}
       </main>
 


### PR DESCRIPTION
## Summary

Improves navigation and journal UX by replacing the scroll-up navbar reveal with an explicit bottom-left chevron control, consolidating weekly summary access into the journal history header, and tightening the history page layout.

## Changes

### Navigation
- Navbar is visible by default only on `/` and `/course`; hidden on all other routes.
- Scroll-down still hides the bar; scroll-up no longer reveals it.
- When hidden, a bottom-left chevron-up button is the only way to show the bar again (button hides while the bar is visible).
- Adds `frontend/public/icons/chevron-up.svg` and styles for the reveal button, including desktop alignment with the centered 700px bar.

### Journal summary access
- Removes the "Resumen semanal" link from the journal writing page (`/journal`); the availability banner remains.
- Moves summary access to a "Resumen" button next to "Escribir" in the journal history header.
- Removes the footer "Resumen semanal" link; footer "ESCRIBIR" button remains.
- Adds responsive header layout: on narrow screens, title and buttons stack with equal-width action buttons; from 600px up, title-left / actions-right.

### Journal history layout
- Reduces top padding on `/journal/history` from 96px to 30px (scoped to the history page wrapper; summary page unchanged).

## Notes
- The history page may show both the "Resumen" header button and the summary availability banner when a summary can be created; both route to `/journal/summary`.
- Navbar default visibility relies on per-page `<Navigation />` remounts on route change.

## Test plan
- [ ] On `/` and `/course`, confirm the navbar is visible on load.
- [ ] On `/journal`, `/journal/history`, `/tests`, and `/instructions`, confirm the navbar is hidden on load.
- [ ] Scroll down on any page and confirm the navbar hides; scroll up and confirm it does **not** reappear.
- [ ] Click the bottom-left chevron button and confirm the navbar appears; confirm the button disappears while the bar is visible.
- [ ] On `/journal`, confirm "Resumen semanal" link is gone but the availability banner still appears when applicable.
- [ ] On `/journal/history`, confirm "Escribir" and "Resumen" appear in the header (stacked on mobile, inline from 600px+).
- [ ] Confirm the footer no longer shows "Resumen semanal".
- [ ] Confirm `/journal/history` top spacing is tighter than `/journal/summary`.
- [ ] Run `npm run lint`, `npm run build`, and `npm run test` in `frontend/`.