### PR TITLE
Journal topic chips: two-row horizontal scroll

### DIFF
--- a/backend/src/journalEntries/journalEntries.controller.js
+++ b/backend/src/journalEntries/journalEntries.controller.js
@@ -10,6 +10,8 @@ export const ALLOWED_JOURNAL_TOPICS = [
   'Reflexión',
   'Sabiduría',
   'Preocupaciones',
+  'Meditaciones',
+  'Privado',
 ];
 
 const MAX_TOPICS = 3;

--- a/backend/src/journalSummaries/prompts.js
+++ b/backend/src/journalSummaries/prompts.js
@@ -48,7 +48,7 @@ export const buildSummaryMessages = ({ entries, weekStart, weekEnd }) => {
     '{"summary":"string","mainTopics":["string"],"bestQuote":"string","socratic":"string"}',
     'Rules:',
     '- summary: 2–4 short paragraphs that mirror what they wrote and the main themes. Address the user directly in second person (tú / "you"), as if speaking to them — e.g. "Has estado pensando…", never third person like "the author" / "el autor del diario". Do not invent facts. Do not diagnose. Do not use clinical jargon.',
-    '- mainTopics: 2 to 5 short labels (may align with Trabajo, Interpersonal, Reflexión, Sabiduría, Preocupaciones, or other precise labels).',
+    '- mainTopics: 2 to 5 short labels (may align with Trabajo, Interpersonal, Reflexión, Sabiduría, Preocupaciones, Meditaciones, Privado, or other precise labels).',
     '- bestQuote: one BRIEF sentence or passage taken nearly verbatim from the user\'s text. Do not invent. If you must shorten it, use an ellipsis…',
     '- socratic: ONE sharp Socratic question or challenge that forces examination of a belief or contradiction. No soft advice. No sermons. Do not say "you should" / "deberías". Do not diagnose.',
     '- Write every user-facing string value (summary, mainTopics, bestQuote, socratic) in Spanish.',

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -44,11 +44,30 @@
 }
 
 .journal-page__topics {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-rows: repeat(2, auto);
+  grid-template-columns: repeat(var(--topic-cols, 3), max-content);
   gap: 8px;
-  justify-content: left;
   width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--accent) 35%, transparent) transparent;
+}
+
+.journal-page__topics::-webkit-scrollbar {
+  height: 4px;
+}
+
+.journal-page__topics::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: 999px;
+}
+
+.journal-page__topics::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .journal-page__topic-chip {

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -189,6 +189,9 @@ const Journal = () => {
             className="journal-page__topics"
             role="group"
             aria-label="Temas del diario"
+            style={{
+              '--topic-cols': Math.max(1, Math.ceil(JOURNAL_TOPICS.length / 2)),
+            }}
           >
             {JOURNAL_TOPICS.map((topic) => {
               const selected = selectedTopics.includes(topic);

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -19,6 +19,8 @@ const JOURNAL_TOPICS = [
   'Reflexión',
   'Sabiduría',
   'Preocupaciones',
+  'Meditaciones',
+  'Privado',
 ];
 
 const MAX_SELECTED_TOPICS = 3;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the journal topic chips so they stay in **two rows** and scroll **horizontally** when there are too many to fit on screen.

Also adds two new selectable topics: **Meditaciones** and **Privado**.

## Approach
- Replaced `flex-wrap` with a 2-row CSS grid.
- Column count is `ceil(topics / 2)`, so chips fill left-to-right across two rows (same feel as today with 5 chips: 3 on top, 2 on bottom).
- `overflow-x: auto` lets users swipe/scroll sideways; chips can appear clipped at the edge as a cue that more content exists.
- Extended the frontend chip list and backend allowlist so the new topics can be selected and stored on journal entries (same max of 3 topics per entry).

## Files
- `frontend/src/Pages/Journal/Journal.jsx` — sets `--topic-cols` from the topics list length; adds Meditaciones and Privado
- `frontend/src/Pages/Journal/Journal.css` — two-row grid + horizontal overflow styles
- `backend/src/journalEntries/journalEntries.controller.js` — allowlist for the new topics
- `backend/src/journalSummaries/prompts.js` — mention new topics in summary guidance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fccc4-eaba-7948-bfa4-b3668a639c3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fccc4-eaba-7948-bfa4-b3668a639c3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

