### PR TITLE
Update AI workflow documentation

### DIFF
--- a/.cursor/docs/architecture.md
+++ b/.cursor/docs/architecture.md
@@ -1,0 +1,205 @@
+# Detox Mental Architecture
+
+This document describes the architecture that new work should follow. It is a
+practical map of the current repository, not a list of aspirational patterns.
+For detailed authentication decisions, environment variables, and historical
+trade-offs, also read `AUTH_ARCHITECTURE.md`, `ENV_SETUP.md`, and `DECISIONS.md`.
+
+## 1. Repository shape
+
+Detox Mental is a monorepo with two independently managed JavaScript packages:
+
+```text
+detox_mental/
+├── frontend/          # React + Vite single-page application
+├── backend/           # Express API and PostgreSQL access
+├── docs/              # Cross-project workflows and feature documentation
+├── .cursor/docs/      # AI implementation and review instructions
+├── .cursor/rules/     # Always-applied engineering conventions
+├── AUTH_ARCHITECTURE.md
+├── DECISIONS.md
+└── ENV_SETUP.md
+```
+
+There is no root package manager configuration. Run package scripts separately
+from `frontend/` and `backend/`.
+
+## 2. Frontend
+
+### Stack and entry points
+
+- React 19 with JavaScript/JSX
+- Vite for development and production builds
+- React Router for client-side routing
+- Vitest and Testing Library for tests
+- ESLint for static analysis
+
+`frontend/src/main.jsx` mounts `App`. `frontend/src/App.jsx` owns the provider
+tree and route table:
+
+```text
+BrowserRouter
+├── ScrollToTop
+└── AuthProvider
+    ├── AuthSessionToast
+    └── SessionsProvider
+        └── Routes
+```
+
+The Vite development server is configured on port `3001` in
+`frontend/vite.config.js`.
+
+### Routing and access
+
+Public routes include onboarding, login, authentication errors, and payment
+results. The rest of the application is nested under `OnboardingGate`, which
+checks the `onboardingRevealed` local-storage flag.
+
+`OnboardingGate` is not an authentication gate. Pages that require an account
+must check `useAuth()` or rely on a protected backend endpoint. Authentication
+and authorization must always be enforced by the backend for user-owned data.
+
+### Source organization
+
+- `src/Pages/<Feature>/`: route-level screens and feature-specific styles,
+  helpers, loading views, and tests.
+- `src/Components/<Component>/`: reusable interface components.
+- `src/Context/`: application-wide React state. Add context only for state
+  shared across distant screens or long-lived application flows.
+- `src/api/client.js`: the common API transport (`apiFetch`), base URL, JSON
+  serialization, and cookie credentials.
+- `src/data/`: static product content and configuration.
+- `src/utils/`: reusable pure utilities and their tests.
+- `src/lib/`: small infrastructure utilities such as the toast event bus.
+
+Keep feature-specific code with its page until reuse clearly justifies moving
+it. Follow existing BEM-style CSS names and global design tokens from
+`src/index.css`.
+
+### State and API conventions
+
+- `AuthContext` bootstraps the session through `GET /auth/me` and exposes
+  `user`, `status`, `refreshUser`, and `logout`.
+- `SessionsContext` combines static course content with persisted unlock state.
+- Local UI state stays inside its page or component.
+- Use `apiFetch` for backend requests so the configured API base URL and
+  HTTP-only authentication cookie are handled consistently.
+- Onboarding chat is the exception: it uses `VITE_CHAT_API_URL` and sends the
+  client-held conversation state with each request. Locally this targets
+  Express `/chat`; production targets the stateless `/api/chat` handler.
+- Check `response.ok`, parse backend error messages when useful, and expose
+  loading, empty, success, and error states appropriate to the feature.
+- Do not put secrets or JWTs in browser storage. The JWT is intentionally held
+  in an HTTP-only cookie.
+
+### Frontend testing
+
+Place focused tests near the implementation as `*.test.js` or `*.test.jsx`.
+Prioritize user-observable behavior and pure business logic. Avoid testing
+implementation details that make harmless refactors expensive.
+
+## 3. Backend
+
+### Stack and entry points
+
+- Node.js 22 with ES modules
+- Express 5
+- PostgreSQL through `pg` (no ORM)
+- Node's built-in test runner
+- ESLint
+
+`backend/src/index.js` configures CORS, Stripe's raw webhook body, JSON parsing,
+cookies, and the `/chat`, `/auth`, and `/stripe` route groups. It starts a local
+server outside Vercel and exports the Express app for serverless deployment.
+
+`backend/api/chat.js` is the stateless Vercel handler for onboarding chat. Keep
+its accepted input and response shape aligned with the local Express chat path.
+Do not introduce server-held chat session state without an explicit
+architecture decision.
+
+### Feature layering
+
+Backend features are grouped by domain, for example:
+
+```text
+src/journalEntries/
+├── journalEntries.controller.js  # HTTP validation and responses
+└── journalEntries.service.js     # SQL and domain persistence
+```
+
+Use the existing layers:
+
+1. **Route**: declares path, HTTP method, middleware, and controller.
+2. **Controller**: validates request input, calls services, selects status codes,
+   returns JSON, and handles expected errors.
+3. **Service**: performs parameterized SQL or external-service operations and
+   maps persistence data into API-friendly objects.
+
+Do not place SQL in React components or frontend code. Do not trust a client
+supplied user ID for user-owned resources; protected controllers use
+`req.user.id`, populated by `requireAuth`.
+
+### Authentication
+
+Authentication uses passwordless magic links:
+
+1. `POST /auth/login` creates and emails a short-lived token.
+2. `GET /auth/verify` validates it, creates or updates the user, and issues a
+   JWT in an HTTP-only cookie.
+3. `requireAuth` validates the cookie and loads the active user from PostgreSQL.
+4. `GET /auth/me` lets the SPA bootstrap authenticated user state.
+
+Protected user resources live under `/auth/me/...` and apply `requireAuth`.
+They are currently registered together in `backend/src/auth/auth.routes.js`,
+even when their controllers and services belong to domains such as journal
+entries or session unlocks.
+Cookie-enabled CORS requires the frontend and backend environment origins to
+remain aligned.
+
+## 4. Database
+
+PostgreSQL access is centralized in `backend/src/db/db.js` through a shared
+`pg.Pool` configured by `DATABASE_URL`.
+
+- Schema changes are raw, numbered SQL files in `backend/src/db/migrations/`.
+- Add migrations; do not rewrite an already-applied migration.
+- Use `snake_case` plural table names and `snake_case` columns.
+- Use UUID primary keys for user-owned records unless the domain already uses a
+  different stable key.
+- Use `*_id` foreign keys and `*_at` timestamp names.
+- Use constraints for data integrity and indexes for demonstrated query paths.
+- User-owned foreign keys normally use `ON DELETE CASCADE`.
+- SQL must be parameterized (`$1`, `$2`, ...) rather than interpolated.
+- API responses use JavaScript-friendly camelCase, mapped in the service layer.
+
+Migrations are currently applied manually to each environment. Document the
+application command and verify the resulting schema in the feature handoff.
+
+## 5. External services and deployment
+
+- PostgreSQL stores users, auth tokens, progress, journal data, and summaries.
+- Resend sends magic-link emails.
+- Stripe provides Checkout and webhook-driven payment updates.
+- Hugging Face powers onboarding, journal transcription, and weekly summaries.
+- Frontend and backend deploy as separate Vercel projects.
+
+Configuration belongs in environment variables described by `ENV_SETUP.md`.
+Never commit `.env` files, API keys, database URLs, raw tokens, or webhook
+secrets.
+
+## 6. Change conventions
+
+For new work:
+
+1. Extend an existing feature module when ownership is clear.
+2. Introduce a new module only when it represents a distinct domain.
+3. Reuse established providers, API transport, middleware, components, and
+   styles before adding abstractions.
+4. Keep frontend authorization UX separate from backend authorization checks.
+5. Add tests for new business rules, parsing, validation, or important user
+   behavior.
+6. Record significant architectural or product trade-offs in `DECISIONS.md`.
+7. Update relevant documentation when routes, environment variables, schema,
+   deployment behavior, or developer commands change.
+8. Keep user-facing product copy in Spanish and implementation names/comments
+   in English, following the dominant repository convention.

--- a/.cursor/docs/definition-of-done.md
+++ b/.cursor/docs/definition-of-done.md
@@ -1,0 +1,90 @@
+# Definition of Done
+
+A feature, fix, or refactor is done only when the applicable conditions below
+are satisfied. Items that do not apply must be explicitly marked as such in the
+final report rather than silently skipped.
+
+## 1. Acceptance criteria
+
+Before implementation, define a small set of observable acceptance criteria
+from the approved plan. Each criterion should describe behavior that a person
+can verify, not an implementation detail.
+
+Basic template:
+
+```text
+Given <starting state>
+When <user or system action>
+Then <observable result>
+```
+
+For a typical feature, cover at minimum:
+
+- **Primary path:** the intended user action succeeds.
+- **Validation/error path:** invalid input or a failed dependency produces a
+  controlled response and useful feedback.
+- **State variants:** relevant loading, empty, authenticated/guest, or
+  permission states behave correctly.
+- **Persistence:** created or changed data is retained and scoped to the correct
+  user when persistence is part of the feature.
+
+Keep acceptance criteria proportional to the change. A small correction may
+need only one or two criteria; a cross-stack feature will need more.
+
+## 2. Implementation
+
+- The approved acceptance criteria are satisfied.
+- The change follows `.cursor/docs/architecture.md` and existing conventions.
+- Scope is limited to the requested work; unrelated cleanup is excluded.
+- Existing components and utilities are reused where reasonable.
+- Input is validated at the appropriate trust boundary.
+- Loading, empty, success, and error states are handled where relevant.
+- User-owned backend operations enforce authentication and ownership.
+- Accessibility basics are present: semantic HTML, labels, keyboard access, and
+  visible focus behavior for interactive controls.
+- New dependencies and architectural changes are justified.
+- Schema or environment changes include migration/setup documentation.
+
+## 3. Testing and automated validation
+
+- Tests are added or updated for new business rules and meaningful regression
+  risk.
+- Frontend and backend lint complete without errors.
+- Warnings are reviewed and either fixed or documented as pre-existing or
+  intentionally accepted.
+- The frontend production build succeeds.
+- Frontend and backend tests pass without unexplained skips.
+- The structured AI code review finds no unresolved Critical issues.
+- Important review findings are fixed or explicitly deferred with a reason.
+
+The exact commands and order are defined in `docs/harness.md`.
+
+## 4. Human verification
+
+- The final Git diff is reviewed for correctness, scope, accidental files,
+  generated output, debug code, and secrets.
+- The acceptance criteria are manually smoke-tested in the relevant user
+  states and viewport(s).
+- Existing behavior near the changed area receives a focused regression check.
+- Database migrations are verified in a safe environment before production.
+- The implementation and any known limitations are understood by the human
+  reviewer; AI output is not accepted solely because automated checks pass.
+
+## 5. Documentation and handoff
+
+- Relevant architecture, environment, schema, API, and product documentation is
+  updated.
+- The final report states:
+  - what changed
+  - validation performed
+  - known limitations
+  - deferred follow-up work
+  - migration/deployment steps, when applicable
+- A concise commit message is proposed.
+- The branch is ready for a focused pull request with a summary and test plan.
+
+## 6. Final gate
+
+Do not commit, open a pull request, merge, or deploy partially validated work.
+If a required condition cannot be completed, report the blocker and treat the
+change as not done.

--- a/.cursor/docs/feature-workflow.md
+++ b/.cursor/docs/feature-workflow.md
@@ -11,8 +11,17 @@ Read:
 - `.cursor/docs/architecture.md`
 - `.cursor/docs/definition-of-done.md`
 - `.cursor/docs/code-review-checklist.md`
+- the approved implementation plan
+- the files directly involved in the change and their nearest tests
 
 Apply the engineering principles (`.cursor/rules/engineering-principles.mdc`).
+
+Translate the approved plan into concise, observable acceptance criteria before
+editing code. At minimum, identify the primary success path and the relevant
+error, empty, loading, authentication, or persistence behavior.
+
+Confirm that the planned change fits the current architecture. Explain any
+significant deviation before implementation.
 
 ---
 
@@ -24,11 +33,24 @@ Keep changes focused.
 
 Avoid unrelated refactoring.
 
+Implement against the acceptance criteria. Add or update focused tests for new
+business rules and meaningful regression risks.
+
+Update documentation when the change affects architecture, API routes,
+database migrations, environment variables, deployment, or developer setup.
+
 ---
 
 ## 3. Validate
 
-Run the validation harness (steps 1-4 of `docs/harness.md`): static analysis, build verification, test execution, and AI code review.
+Run the complete validation harness in `docs/harness.md`:
+
+1. static analysis
+2. build verification
+3. test execution
+4. structured AI code review
+5. human final-diff review and smoke testing
+6. final completion decision
 
 Resolve failures before continuing.
 
@@ -39,9 +61,16 @@ Resolve failures before continuing.
 Summarize:
 
 - what changed
+- which acceptance criteria were verified
+- validation and smoke tests performed
 - remaining limitations
 - possible future improvements
+- migration or deployment steps, when applicable
 
 ## 5. Provide commit description
 
 End the task by providing a recommended commit message reflecting the changes made.
+
+After human approval, create a focused commit and pull request with a concise
+summary and test plan. Do not commit, open a pull request, merge, or deploy
+without explicit human authorization.

--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -24,7 +24,7 @@ Variables are read via `dotenv` when you run `npm run dev` / `npm start` in `bac
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `PORT` | No | HTTP port (default `3000`). |
-| `FRONTEND_ORIGIN` | Yes | Origin of the web app (e.g. `http://localhost:5173`). Used for **CORS**, magic-link redirects, and **Stripe Checkout** `success_url` / `cancel_url`. Must match the URL users open in the browser (scheme + host + port). |
+| `FRONTEND_ORIGIN` | Yes | Origin of the web app (locally `http://localhost:3001`). Used for **CORS**, magic-link redirects, and **Stripe Checkout** `success_url` / `cancel_url`. Must match the URL users open in the browser (scheme + host + port). |
 | `NODE_ENV` | For prod behavior | Set `production` on deployed API so cookies use `Secure` and DB SSL matches `db.js`. |
 
 ### Database

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Set local env files at minimum:
 
 - `backend/.env`
   - `DATABASE_URL`
-  - `FRONTEND_ORIGIN=http://localhost:5173` (or your local frontend URL)
+  - `FRONTEND_ORIGIN=http://localhost:3001` (or your local frontend URL)
   - `JWT_SECRET`
   - `MAGIC_LINK_SECRET`
   - `RESEND_API_KEY`
@@ -88,7 +88,7 @@ cd frontend
 npm run dev
 ```
 
-Frontend usually runs on `http://localhost:5173`.
+Frontend runs on `http://localhost:3001` as configured in `frontend/vite.config.js`.
 
 ## Production Notes
 

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -14,7 +14,20 @@ The steps must be executed in this exact order:
 
 ---
 
-This is a monorepo with two independent packages (`frontend/` and `backend/`), each with its own `package.json` and tooling. Run every step below in **both** directories.
+This is a monorepo with two independent packages (`frontend/` and `backend/`),
+each with its own `package.json` and tooling. Run package commands in both
+directories where the step says to do so.
+
+## 0. Acceptance criteria and scope
+
+Before validation, record the observable acceptance criteria defined during
+planning and identify the files intentionally changed.
+
+### Requirement:
+
+- Every acceptance criterion can be verified through a test or manual check
+- The diff contains no unrelated refactoring
+- Any intentionally deferred behavior is documented
 
 ## 1. Static analysis
 
@@ -73,12 +86,34 @@ All Critical issues must be fixed
 
 ## 5. Human review
 
-Manually evaluate:
+### Final diff review
+
+Review the complete Git diff, including staged, unstaged, and untracked files.
+Check for:
+
+- correctness and alignment with the approved plan
+- unrelated changes or accidental generated files
+- debug statements, dead code, and temporary comments
+- secrets, credentials, `.env` files, or sensitive user data
+- schema/configuration changes that need operational instructions
+- adequate tests for the regression risk
+
+### Manual smoke test
+
+Exercise each acceptance criterion in the running application. Include the
+relevant user states, such as authenticated/guest, success/error, and
+empty/populated data. Check the affected viewport sizes and keyboard interaction
+when the UI is responsive or interactive.
+
+Also evaluate:
 
 - Does the feature behave as intended?
 - Does it introduce unnecessary complexity?
 - Does it align with existing architecture?
 - Is the UI/UX consistent with the project?
+- Does nearby existing behavior still work?
+
+Record what was tested and any limitations in the final report.
 
 ## 6. Final decision
 
@@ -88,8 +123,22 @@ Only proceed to commit if all conditions are met:
 - build passes
 - tests pass
 - critical review issues resolved
+- acceptance criteria manually verified
+- final diff reviewed
+- no secrets or unrelated changes included
 - feature is complete and scoped correctly
 
+## Pull request readiness
+
+After the final decision passes, prepare a focused commit and pull request:
+
+- concise title describing the outcome
+- summary of behavior and relevant technical decisions
+- test plan listing automated checks and manual smoke tests
+- migration, environment, rollout, or rollback notes when applicable
+- known limitations or explicitly deferred follow-ups
+
+Opening a commit or pull request still requires explicit human authorization.
 
 ## Commit rule
 


### PR DESCRIPTION
## Summary

Updates AI workflow and developer documentation so implementation, validation, and handoff follow clearer acceptance criteria and a fuller definition of done. Also corrects the local frontend origin/port docs to match Vite’s configured `3001`.

## Changes

### AI / agent workflow
- Add `.cursor/docs/architecture.md` as a practical map of the monorepo (frontend/backend layout, routing, API conventions).
- Add `.cursor/docs/definition-of-done.md` with acceptance-criteria, testing, human verification, and final-gate requirements.
- Expand `.cursor/docs/feature-workflow.md` to require plan-derived acceptance criteria, focused tests/docs updates, full harness validation (including human review), and explicit human authorization before commit/PR.

### Validation harness
- Extend `docs/harness.md` with scope/acceptance-criteria checks, stronger human final-diff + smoke-test guidance, PR readiness notes, and a clearer final completion gate.

### Local setup docs
- Align `README.md` and `ENV_SETUP.md` so `FRONTEND_ORIGIN` / local frontend URL use `http://localhost:3001` (matching `frontend/vite.config.js`) instead of `5173`.

## Notes
- Documentation-only change; no application code, migrations, or env defaults were modified.
- Branch is already tracking remote as `chore/update-repo-documentation` (one commit ahead of `main`: `Update AI workflow documentation`).

## Test plan
- [ ] Skim the new/updated docs for accuracy against the current repo layout and Vite port.
- [ ] Confirm `FRONTEND_ORIGIN=http://localhost:3001` matches local `frontend/vite.config.js` and a working local CORS setup.
- [ ] Spot-check that feature workflow + harness steps still reference existing files (architecture, definition-of-done, code-review checklist).