### PR TITLE
Update LLM model for text processing

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -59,7 +59,7 @@ Use **test** keys and a **test** price while developing; no real money moves in 
 |----------|----------|-------------|
 | `HF_TOKEN` | Yes for `/chat`, journal image transcription, and weekly journal summaries | Hugging Face API token. Needs "Inference Providers" permission. Used by the chat controller, journal handwriting transcription, and weekly journal summary generation. |
 | `HF_JOURNAL_VISION_MODEL` | No | Vision-language model used to transcribe handwritten journal images. Defaults to `Qwen/Qwen3-VL-30B-A3B-Instruct:novita`. Override to swap models without code changes. |
-| `HF_JOURNAL_SUMMARY_MODEL` | No | Text model for weekly journal summaries. Defaults to `meta-llama/Llama-3.1-8B-Instruct:novita`. |
+| `HF_JOURNAL_SUMMARY_MODEL` | No | Text model for weekly journal summaries. Defaults to `moonshotai/Kimi-K2-Instruct-0905:novita`. |
 
 Journal transcription uploads are processed in memory only: the image is sent to the model and never written to disk or the database. Only the transcribed text is returned to the client for review before saving.
 

--- a/backend/src/journalSummaries/journalSummaries.generation.js
+++ b/backend/src/journalSummaries/journalSummaries.generation.js
@@ -5,7 +5,7 @@ import {
   parseSummaryOutput,
 } from './parseSummaryOutput.js';
 
-const DEFAULT_SUMMARY_MODEL = 'meta-llama/Llama-3.1-8B-Instruct:novita';
+const DEFAULT_SUMMARY_MODEL = 'moonshotai/Kimi-K2-Instruct-0905:novita';
 
 export const getSummaryModelId = () =>
   process.env.HF_JOURNAL_SUMMARY_MODEL || DEFAULT_SUMMARY_MODEL;


### PR DESCRIPTION
## Summary

Switches the weekly journal summary generation model from Meta's Llama 3.1 8B to Moonshot AI's Kimi K2 Instruct (0905), for higher-quality long-form philosophical reflections without any client/provider changes.

## Changes

### Journal summaries
- `backend/src/journalSummaries/journalSummaries.generation.js`: updated `DEFAULT_SUMMARY_MODEL` to `moonshotai/Kimi-K2-Instruct-0905:novita` (still overridable via `HF_JOURNAL_SUMMARY_MODEL`).
- `ENV_SETUP.md`: updated the documented default for `HF_JOURNAL_SUMMARY_MODEL` to match.

## Notes
- Same Hugging Face Inference Providers setup (`HF_TOKEN`, Novita provider) — no new HF permissions or provider enablement required.
- Uses the non-thinking `Instruct` variant (not `Kimi-K2-Thinking`) to avoid extra hidden reasoning tokens against the existing `max_tokens: 3200` budget.
- Anyone with `HF_JOURNAL_SUMMARY_MODEL` already set in their local/deployed `.env` will need to update or unset it to pick up the new default.

## Test plan
- [ ] Trigger a weekly journal summary generation locally and confirm a valid JSON response (`summary`, `mainTopics`, `bestQuote`, `socratic`) is parsed successfully.
- [ ] Spot-check the generated reflection quality/tone in Spanish against the existing system prompt expectations.
- [ ] Confirm `HF_JOURNAL_SUMMARY_MODEL` override still works if set.