### PR TITLE
Chore: polish interface

### DIFF
--- a/frontend/src/Components/Navigation/Navigation.css
+++ b/frontend/src/Components/Navigation/Navigation.css
@@ -1,25 +1,3 @@
-.navigation {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 20;
-    display: flex;
-    width: 100%;
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-    border-top: 1px solid var(--background);
-    background-color: var(--accent);
-    border-top-left-radius: 14px;
-    border-top-right-radius: 14px;
-    overflow: hidden;
-    transform: translateY(110%);
-    transition: transform 220ms ease;
-}
-
-.navigation--visible {
-    transform: translateY(0);
-}
-
 .navigation__reveal {
     position: fixed;
     left: 12px;
@@ -50,61 +28,6 @@
 .navigation__reveal-icon {
     width: 22px;
     height: 22px;
-}
-
-.navigation__section {
-    flex: 1;
-    min-height: 51px;
-    border: none;
-    background: transparent;
-    color: var(--background);
-    font-size: 13px;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-}
-
-.navigation__section--left {
-    position: relative;
-}
-
-.navigation__section--left::after {
-    content: "";
-    position: absolute;
-    right: 0;
-    top: 15%;
-    bottom: 15%;
-    width: 1px;
-    background: var(--background);
-}
-
-.navigation__section--right {
-    padding: 0 14px;
-    overflow: hidden;
-}
-
-.navigation__section--right-user {
-    justify-content: center;
-    gap: 9px;
-}
-
-.navigation__user-email {
-    min-width: 0;
-    text-align: left;
-    white-space: nowrap;
-}
-
-.navigation__account-icon {
-    width: 24px;
-    height: 24px;
-    flex-shrink: 0;
-}
-
-.navigation__icon {
-    width: 26px;
-    height: 26px;
 }
 
 .navigation__menu-overlay {
@@ -165,6 +88,11 @@
     color: var(--accent);
 }
 
+.navigation__menu-link:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .navigation__menu-link--promo {
     background: #f8E5A5;
     color: var(--accent);
@@ -191,11 +119,6 @@
 }
 
 @media (min-width: 1000px) {
-    .navigation {
-        max-width: 700px;
-        margin: 0 auto;
-    }
-
     .navigation__reveal {
         left: max(12px, calc(50% - 350px + 12px));
     }

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -4,19 +4,16 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../Context/AuthContext.jsx';
 import { isPromoEnabled } from '../../data/promoConfig.js';
 
-const isVisibleByDefault = (pathname) =>
-    pathname === '/' || pathname.startsWith('/course');
-
 const Navigation = () => {
     const [menuState, setMenuState] = useState('closed');
     const navigate = useNavigate();
     const location = useLocation();
-    const [isBarVisible, setIsBarVisible] = useState(() => isVisibleByDefault(location.pathname));
     const { user, status } = useAuth();
     const isCourseRoute = location.pathname.startsWith('/course') || location.pathname.startsWith('/session');
     const isTestsRoute = location.pathname.startsWith('/tests') || location.pathname.startsWith('/test');
     const isJournalRoute = location.pathname.startsWith('/journal');
     const isPromoRoute = location.pathname.startsWith('/promo');
+    const isAccountRoute = location.pathname.startsWith('/account') || location.pathname.startsWith('/login');
     const menuLinks = [
         { label: 'TEORÍA', path: '/', isActive: location.pathname === '/' },
         { label: 'CURSO', path: '/course', isActive: isCourseRoute },
@@ -26,6 +23,12 @@ const Navigation = () => {
             label: 'INSTRUCCIONES',
             path: '/instructions',
             isActive: location.pathname.startsWith('/instructions'),
+        },
+        {
+            label: user ? 'CUENTA' : 'LOGIN',
+            path: user ? '/account' : '/login',
+            isActive: isAccountRoute,
+            disabled: !user && status !== 'ready',
         },
     ];
 
@@ -51,19 +54,6 @@ const Navigation = () => {
         return () => document.removeEventListener('keydown', onKeyDown);
     }, [menuState]);
 
-    useEffect(() => {
-        let lastY = window.scrollY;
-        const onScroll = () => {
-            const currentY = window.scrollY;
-            if (currentY > lastY + 6) {
-                setIsBarVisible(false);
-            }
-            lastY = currentY;
-        };
-        window.addEventListener('scroll', onScroll, { passive: true });
-        return () => window.removeEventListener('scroll', onScroll);
-    }, []);
-
     return (
         <>
             {menuState !== 'closed' && (
@@ -86,6 +76,7 @@ const Navigation = () => {
                             <button
                                 key={link.path}
                                 type='button'
+                                disabled={link.disabled}
                                 className={`navigation__menu-link${link.isActive ? ' navigation__menu-link--active' : ''}`}
                                 onClick={() => goTo(link.path)}
                             >
@@ -104,52 +95,21 @@ const Navigation = () => {
                     </div>
                 </div>
             )}
-            {!isBarVisible && (
+            {menuState === 'closed' && (
                 <button
                     type='button'
                     className='navigation__reveal'
-                    onClick={() => setIsBarVisible(true)}
-                    aria-label='Mostrar navegación'
+                    onClick={openMenu}
+                    aria-label='Abrir menú'
                 >
                     <img
                         className='navigation__reveal-icon'
-                        src='/icons/chevron-up.svg'
+                        src='/images/menu.svg'
                         alt=''
                         aria-hidden='true'
                     />
                 </button>
             )}
-            <div className={`navigation${isBarVisible ? ' navigation--visible' : ''}`}>
-                <button type='button' className='navigation__section navigation__section--left' onClick={openMenu}>
-                    <img
-                        className="navigation__icon"
-                        src='/images/menu.svg'
-                        alt="Menú"
-                    />
-                </button>
-                <button
-                    type='button'
-                    className={`navigation__section navigation__section--right${user ? ' navigation__section--right-user' : ''}`}
-                    onClick={
-                        user
-                            ? () => goTo('/account')
-                            : (!user && status === 'ready' ? () => goTo('/login') : undefined)
-                    }
-                >
-                    {user ? (
-                        <>
-                            <span className='navigation__user-email'>
-                                PERFIL
-                            </span>
-                            <img
-                                className='navigation__account-icon'
-                                src='/icons/account.svg'
-                                alt='Cuenta'
-                            />
-                        </>
-                    ) : 'LOGIN'}
-                </button>
-            </div>
         </>
     );
 }

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -472,6 +472,7 @@
   line-height: 1.5;
   color: var(--text);
   white-space: pre-wrap;
+  font-size: 17px;
 }
 
 .journal-history__excerpt--toggleable {

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -449,7 +449,7 @@
 
 .journal-history__topics {
   list-style: none;
-  margin: 0 0 12px;
+  margin: 0 0 14px;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
@@ -457,13 +457,14 @@
 }
 
 .journal-history__topic-chip {
-  padding: 4px 10px;
+  padding: 7px 14px;
   border-radius: 999px;
   background: var(--accent);
   color: var(--background);
   font-size: 12px;
   font-weight: 600;
   line-height: 1.3;
+  margin-bottom: 0px;
 }
 
 .journal-history__excerpt {


### PR DESCRIPTION
## Summary

Simplifies the mobile navigation to a single hamburger-triggered overlay menu, folding the account/login action into it, and makes small readability fixes to the journal history list (topic chips and excerpt text).

## Changes

### Navigation
- Removed the fixed bottom navigation bar (`.navigation`, its scroll-based show/hide logic, and the `isBarVisible` state) entirely.
- The floating round button is now a persistent hamburger trigger: it always renders while the overlay is closed (no scroll dependency), uses the `/images/menu.svg` hamburger icon, and opens the overlay directly on click. It hides while the overlay is open/closing.
- Added a `CUENTA` / `LOGIN` entry to the overlay's link list (last item, before the promo link), reusing the same button styling as `TEORÍA`, `CURSO`, `TESTS`, etc. It navigates to `/account` or `/login`, highlights active on either route, and is disabled until auth status is `'ready'` when logged out.
- Removed now-unused CSS for the old bar layout and added a `.navigation__menu-link:disabled` style for the disabled login state.

### Journal history
- Increased spacing/padding around topic chips (`.journal-history__topics` margin, `.journal-history__topic-chip` padding) for a less cramped look.
- Reduced the journal entry excerpt font size (`.journal-history__excerpt`) for better readability at a glance.

## Notes
- No new dependencies or environment changes.
- No automated tests exist for `Navigation.jsx`; changes were validated via lint, production build, and the existing Journal test suite.

## Test plan
- [ ] Open the app and confirm no bottom bar renders on any route.
- [ ] Confirm the hamburger button is fixed bottom-left at all times (including after scrolling) and disappears while the overlay is open.
- [ ] Open the overlay and verify link order: TEORÍA, CURSO, TESTS, DIARIO, INSTRUCCIONES, CUENTA/LOGIN (promo link last, if enabled).
- [ ] Verify `CUENTA`/`LOGIN` navigates correctly for logged-in and logged-out states, and is disabled while auth status is loading.
- [ ] Verify Escape key and background click still close the overlay.
- [ ] Check the journal history topic chips and entry excerpt text render with the updated spacing/sizing.