### PR TITLE
Feature: Journal demo mode

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import Journal from './Pages/Journal/Journal.jsx';
 import JournalHistory from './Pages/Journal/JournalHistory.jsx';
 import JournalSummary from './Pages/Journal/JournalSummary.jsx';
 import ScrollToTop from './Components/ScrollToTop/ScrollToTop.jsx';
+import { DemoModeProvider } from './Context/DemoModeContext.jsx';
 
 const App = () => {
     return (
@@ -29,30 +30,32 @@ const App = () => {
                 <ScrollToTop />
                 <AuthProvider>
                     <AuthSessionToast />
-                <SessionsProvider>
-                    <Routes>
-                        <Route path='/onboarding' element={<OnboardingWrapper />} />
-                        <Route path='/login' element={<Login />} />
-                        <Route path='/auth/error' element={<AuthError />} />
-                        <Route path='/payment/success' element={<PaymentSuccess />} />
-                        <Route path='/payment/cancel' element={<PaymentCancel />} />
+                    <DemoModeProvider>
+                        <SessionsProvider>
+                            <Routes>
+                                <Route path='/onboarding' element={<OnboardingWrapper />} />
+                                <Route path='/login' element={<Login />} />
+                                <Route path='/auth/error' element={<AuthError />} />
+                                <Route path='/payment/success' element={<PaymentSuccess />} />
+                                <Route path='/payment/cancel' element={<PaymentCancel />} />
 
-                        {/* Onboarding gate (exclude /onboarding to avoid redirect loop) */}
-                        <Route element={<OnboardingGate />}>
-                            <Route path='/' element={<ArticleWrapper />} />
-                            <Route path='course' element={<CourseWrapper />} />
-                            <Route path='promo' element={<PromoGate />} />
-                            <Route path='instructions' element={<Instructions />} />
-                            <Route path='account' element={<Account />} />
-                            <Route path='tests' element={<Tests />} />
-                            <Route path='test/:testId' element={<ThoughtsTest />} />
-                            <Route path='journal/history' element={<JournalHistory />} />
-                            <Route path='journal/summary' element={<JournalSummary />} />
-                            <Route path='journal' element={<Journal />} />
-                            <Route path='session/:sessionId' element={<Session />} />
-                        </Route>
-                    </Routes>
-                </SessionsProvider>
+                                {/* Onboarding gate (exclude /onboarding to avoid redirect loop) */}
+                                <Route element={<OnboardingGate />}>
+                                    <Route path='/' element={<ArticleWrapper />} />
+                                    <Route path='course' element={<CourseWrapper />} />
+                                    <Route path='promo' element={<PromoGate />} />
+                                    <Route path='instructions' element={<Instructions />} />
+                                    <Route path='account' element={<Account />} />
+                                    <Route path='tests' element={<Tests />} />
+                                    <Route path='test/:testId' element={<ThoughtsTest />} />
+                                    <Route path='journal/history' element={<JournalHistory />} />
+                                    <Route path='journal/summary' element={<JournalSummary />} />
+                                    <Route path='journal' element={<Journal />} />
+                                    <Route path='session/:sessionId' element={<Session />} />
+                                </Route>
+                            </Routes>
+                        </SessionsProvider>
+                    </DemoModeProvider>
                 </AuthProvider>
             </BrowserRouter>
         </React.StrictMode>

--- a/frontend/src/Components/DemoModeToggle/DemoModeToggle.css
+++ b/frontend/src/Components/DemoModeToggle/DemoModeToggle.css
@@ -1,13 +1,13 @@
 .demo-mode-toggle {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: start;
   gap: 8px;
   align-self: flex-end;
   padding: 0;
   border: none;
   background: transparent;
-  color: #d63d2e;
+  color: var(--accent);
   font: inherit;
   cursor: pointer;
 }

--- a/frontend/src/Components/DemoModeToggle/DemoModeToggle.css
+++ b/frontend/src/Components/DemoModeToggle/DemoModeToggle.css
@@ -1,0 +1,40 @@
+.demo-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  align-self: flex-end;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #d63d2e;
+  font: inherit;
+  cursor: pointer;
+}
+
+.demo-mode-toggle__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.demo-mode-toggle__box {
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  border: 2px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  transition: background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.demo-mode-toggle--active .demo-mode-toggle__box {
+  background: currentColor;
+  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.9);
+}
+
+.demo-mode-toggle:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 4px;
+  border-radius: 6px;
+}

--- a/frontend/src/Components/DemoModeToggle/DemoModeToggle.jsx
+++ b/frontend/src/Components/DemoModeToggle/DemoModeToggle.jsx
@@ -1,0 +1,22 @@
+import { useDemoMode } from '../../Context/DemoModeContext.jsx';
+import './DemoModeToggle.css';
+
+const DemoModeToggle = () => {
+  const { demoMode, toggleDemoMode } = useDemoMode();
+
+  return (
+    <button
+      type="button"
+      className={`demo-mode-toggle${demoMode ? ' demo-mode-toggle--active' : ''}`}
+      onClick={toggleDemoMode}
+      role="switch"
+      aria-checked={demoMode}
+      aria-label={demoMode ? 'Desactivar modo demo' : 'Activar modo demo'}
+    >
+      <span className="demo-mode-toggle__label">DEMO</span>
+      <span className="demo-mode-toggle__box" aria-hidden="true" />
+    </button>
+  );
+};
+
+export default DemoModeToggle;

--- a/frontend/src/Context/DemoModeContext.jsx
+++ b/frontend/src/Context/DemoModeContext.jsx
@@ -1,0 +1,33 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+const DemoModeContext = createContext(null);
+
+export const DemoModeProvider = ({ children }) => {
+  const [demoMode, setDemoMode] = useState(false);
+
+  const toggleDemoMode = useCallback(() => {
+    setDemoMode((prev) => !prev);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      demoMode,
+      toggleDemoMode,
+    }),
+    [demoMode, toggleDemoMode],
+  );
+
+  return (
+    <DemoModeContext.Provider value={value}>
+      {children}
+    </DemoModeContext.Provider>
+  );
+};
+
+export const useDemoMode = () => {
+  const ctx = useContext(DemoModeContext);
+  if (!ctx) {
+    throw new Error('useDemoMode must be used within a DemoModeProvider');
+  }
+  return ctx;
+};

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -289,26 +289,27 @@
 
 .journal-history__header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
   gap: 16px;
 }
 
-/* Two actions do not fit next to the title on narrow screens, so they move to
-   their own full-width row below it. */
-.journal-history__header--with-actions {
-  flex-direction: column;
-  align-items: stretch;
+.journal-history__header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 12px;
 }
 
 .journal-history__header-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
 }
 
-.journal-history__header--with-actions .journal-history__header-actions > * {
+.journal-history__header-actions > * {
   flex: 1 1 0;
 }
 
@@ -599,12 +600,7 @@
 }
 
 @media (min-width: 600px) {
-  .journal-history__header--with-actions {
-    flex-direction: row;
-    align-items: center;
-  }
-
-  .journal-history__header--with-actions .journal-history__header-actions > * {
+  .journal-history__header-actions > * {
     flex: 0 0 auto;
   }
 }

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -315,6 +315,8 @@
 
 .journal-history__title {
   margin: 0;
+  flex-shrink: 0;
+  white-space: nowrap;
   font-size: 1.5rem;
   color: var(--accent);
 }

--- a/frontend/src/Pages/Journal/JournalHistory.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.jsx
@@ -2,8 +2,11 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Navigation from '../../Components/Navigation/Navigation.jsx';
 import CloseIcon from '../../Components/CloseIcon/CloseIcon.jsx';
+import DemoModeToggle from '../../Components/DemoModeToggle/DemoModeToggle.jsx';
 import { useAuth } from '../../Context/AuthContext.jsx';
+import { useDemoMode } from '../../Context/DemoModeContext.jsx';
 import { apiFetch } from '../../api/client.js';
+import { DEMO_ENTRIES } from '../../data/demoJournal.js';
 import { emitToast } from '../../lib/toastBus.js';
 import JournalSummaryBanner from './JournalSummaryBanner.jsx';
 import './Journal.css';
@@ -31,13 +34,23 @@ const getExcerpt = (content) => {
 
 const JournalHistory = () => {
   const { user, status } = useAuth();
+  const { demoMode } = useDemoMode();
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(false);
   const [expandedIds, setExpandedIds] = useState(() => new Set());
   const [entryPendingDelete, setEntryPendingDelete] = useState(null);
   const [deleting, setDeleting] = useState(false);
+  const visibleEntries = demoMode ? DEMO_ENTRIES : entries;
 
   useEffect(() => {
+    if (demoMode) {
+      setEntries([]);
+      setExpandedIds(new Set());
+      setLoading(false);
+      setEntryPendingDelete(null);
+      return undefined;
+    }
+
     if (status !== 'ready' || !user) {
       setEntries([]);
       setExpandedIds(new Set());
@@ -77,7 +90,7 @@ const JournalHistory = () => {
     return () => {
       cancelled = true;
     };
-  }, [status, user]);
+  }, [demoMode, status, user]);
 
   const toggleExpanded = (entryId) => {
     setExpandedIds((prev) => {
@@ -130,7 +143,10 @@ const JournalHistory = () => {
       <Navigation />
       <main className="journal-page__main journal-page__main--history">
         <header className="journal-history__header journal-history__header--with-actions">
-          <h1 className="journal-history__title">Historial</h1>
+          <div className="journal-history__header-top">
+            <h1 className="journal-history__title">Historial</h1>
+            <DemoModeToggle />
+          </div>
           <div className="journal-history__header-actions">
             <Link
               to="/journal"
@@ -147,13 +163,13 @@ const JournalHistory = () => {
           </div>
         </header>
 
-        <JournalSummaryBanner />
+        {!demoMode && <JournalSummaryBanner />}
 
-        {status === 'loading' && (
+        {!demoMode && status === 'loading' && (
           <p className="journal-history__status">Cargando…</p>
         )}
 
-        {status === 'ready' && !user && (
+        {!demoMode && status === 'ready' && !user && (
           <div className="journal-history__empty">
             <p>Inicia sesión para ver las entradas guardadas en tu diario.</p>
             <Link to="/login" className="journal-history__action-link">
@@ -162,11 +178,11 @@ const JournalHistory = () => {
           </div>
         )}
 
-        {status === 'ready' && user && loading && (
+        {!demoMode && status === 'ready' && user && loading && (
           <p className="journal-history__status">Cargando entradas…</p>
         )}
 
-        {status === 'ready' && user && !loading && entries.length === 0 && (
+        {!demoMode && status === 'ready' && user && !loading && visibleEntries.length === 0 && (
           <div className="journal-history__empty">
             <p>Aún no hay entradas en tu diario.</p>
             <Link to="/journal" className="journal-history__action-link">
@@ -175,9 +191,9 @@ const JournalHistory = () => {
           </div>
         )}
 
-        {status === 'ready' && user && !loading && entries.length > 0 && (
+        {(demoMode || (status === 'ready' && user && !loading && visibleEntries.length > 0)) && (
           <ul className="journal-history__feed">
-            {entries.map((entry) => {
+            {visibleEntries.map((entry) => {
               const expandable = getWordCount(entry.content) > EXCERPT_WORD_COUNT;
               const expanded = expandedIds.has(entry.id);
               const bodyText =
@@ -196,20 +212,22 @@ const JournalHistory = () => {
                     >
                       {formatEntryDate(entry.createdAt)}
                     </time>
-                    <button
-                      type="button"
-                      className="journal-history__delete"
-                      onClick={() => setEntryPendingDelete(entry)}
-                      disabled={deleteDisabled}
-                      aria-label="Eliminar entrada"
-                    >
-                      <img
-                        src="/icons/trash.svg"
-                        alt=""
-                        className="journal-history__delete-icon"
-                        aria-hidden="true"
-                      />
-                    </button>
+                    {!demoMode && (
+                      <button
+                        type="button"
+                        className="journal-history__delete"
+                        onClick={() => setEntryPendingDelete(entry)}
+                        disabled={deleteDisabled}
+                        aria-label="Eliminar entrada"
+                      >
+                        <img
+                          src="/icons/trash.svg"
+                          alt=""
+                          className="journal-history__delete-icon"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    )}
                   </div>
                   {Array.isArray(entry.topics) && entry.topics.length > 0 && (
                     <ul
@@ -258,7 +276,7 @@ const JournalHistory = () => {
           </ul>
         )}
 
-        {status !== 'loading' && (
+        {(demoMode || status !== 'loading') && (
           <Link
             to="/journal"
             className="journal-history__write-button journal-history__write-button--footer"

--- a/frontend/src/Pages/Journal/JournalHistory.test.jsx
+++ b/frontend/src/Pages/Journal/JournalHistory.test.jsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import JournalHistory from './JournalHistory.jsx';
+import { apiFetch } from '../../api/client.js';
+
+const mockUseAuth = vi.fn();
+const mockUseDemoMode = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock('../../Context/AuthContext.jsx', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('../../Context/DemoModeContext.jsx', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}));
+
+vi.mock('../../Components/Navigation/Navigation.jsx', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../Components/CloseIcon/CloseIcon.jsx', () => ({
+  default: () => null,
+}));
+
+vi.mock('./JournalSummaryBanner.jsx', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../api/client.js', () => ({ apiFetch: vi.fn() }));
+vi.mock('../../lib/toastBus.js', () => ({ emitToast: vi.fn() }));
+
+describe('JournalHistory page states', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockUseDemoMode.mockReset();
+    apiFetch.mockReset();
+    mockUseDemoMode.mockReturnValue({
+      demoMode: false,
+      toggleDemoMode: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('prompts guests to log in when demo mode is off', () => {
+    mockUseAuth.mockReturnValue({ user: null, status: 'ready' });
+
+    render(<JournalHistory />);
+
+    expect(
+      screen.getByText(/Inicia sesión para ver las entradas guardadas en tu diario/i),
+    ).toBeTruthy();
+  });
+
+  test('renders demo entries for guests when demo mode is active', () => {
+    mockUseAuth.mockReturnValue({ user: null, status: 'ready' });
+    mockUseDemoMode.mockReturnValue({
+      demoMode: true,
+      toggleDemoMode: vi.fn(),
+    });
+
+    render(<JournalHistory />);
+
+    expect(
+      screen.getByText(/Cada vez que algo queda ambiguo/i),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText(/Eliminar entrada/i)).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/Pages/Journal/JournalSummary.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.jsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import DemoModeToggle from '../../Components/DemoModeToggle/DemoModeToggle.jsx';
 import Navigation from '../../Components/Navigation/Navigation.jsx';
 import { useAuth } from '../../Context/AuthContext.jsx';
+import { useDemoMode } from '../../Context/DemoModeContext.jsx';
 import { apiFetch } from '../../api/client.js';
+import { DEMO_SUMMARY_PAYLOAD } from '../../data/demoJournal.js';
 import { emitToast } from '../../lib/toastBus.js';
 import JournalSummaryLoadingScreen from './JournalSummaryLoadingScreen.jsx';
 import './Journal.css';
@@ -23,6 +26,7 @@ const formatWeekLabel = (weekStart, weekEnd) => {
 
 const JournalSummary = () => {
   const { user, status } = useAuth();
+  const { demoMode } = useDemoMode();
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
@@ -30,6 +34,12 @@ const JournalSummary = () => {
   const [pendingSummary, setPendingSummary] = useState(null);
 
   const loadCurrent = useCallback(async () => {
+    if (demoMode) {
+      setPayload(null);
+      setLoading(false);
+      return;
+    }
+
     if (status !== 'ready' || !user) {
       setPayload(null);
       setLoading(false);
@@ -51,7 +61,7 @@ const JournalSummary = () => {
     } finally {
       setLoading(false);
     }
-  }, [status, user]);
+  }, [demoMode, status, user]);
 
   useEffect(() => {
     loadCurrent();
@@ -114,32 +124,41 @@ const JournalSummary = () => {
     );
   }
 
-  const summary = payload?.summary;
-  const weekLabel = formatWeekLabel(payload?.weekStart, payload?.weekEnd);
+  const effectivePayload = demoMode ? DEMO_SUMMARY_PAYLOAD : payload;
+  const summary = effectivePayload?.summary;
+  const weekLabel = formatWeekLabel(
+    effectivePayload?.weekStart,
+    effectivePayload?.weekEnd,
+  );
 
   return (
     <div className="journal-page journal-page--summary">
       <Navigation />
       <main className="journal-page__main journal-page__main--history">
-        <header className="journal-history__header">
-          <h1 className="journal-history__title">Resumen semanal</h1>
-          <Link
-            to="/journal"
-            className="journal-history__write-button journal-history__write-button--header"
-          >
-            Escribir
-          </Link>
+        <header className="journal-history__header journal-history__header--with-actions">
+          <div className="journal-history__header-top">
+            <h1 className="journal-history__title">Resumen semanal</h1>
+            <DemoModeToggle />
+          </div>
+          <div className="journal-history__header-actions">
+            <Link
+              to="/journal"
+              className="journal-history__write-button journal-history__write-button--header"
+            >
+              Escribir
+            </Link>
+          </div>
         </header>
 
         {weekLabel && (
           <p className="journal-summary__week">{weekLabel}</p>
         )}
 
-        {status === 'loading' && (
+        {!demoMode && status === 'loading' && (
           <p className="journal-history__status">Cargando…</p>
         )}
 
-        {status === 'ready' && !user && (
+        {!demoMode && status === 'ready' && !user && (
           <div className="journal-history__empty">
             <p>Inicia sesión para ver o crear tu resumen semanal.</p>
             <Link to="/login" className="journal-history__action-link">
@@ -148,11 +167,11 @@ const JournalSummary = () => {
           </div>
         )}
 
-        {status === 'ready' && user && loading && (
+        {!demoMode && status === 'ready' && user && loading && (
           <p className="journal-history__status">Cargando resumen…</p>
         )}
 
-        {status === 'ready' && user && !loading && summary && (
+        {(demoMode || (status === 'ready' && user && !loading && summary)) && (
           <div className="journal-summary__result">
             <section className="journal-summary__section">
               <h2 className="journal-summary__heading">Esta semana</h2>
@@ -186,9 +205,9 @@ const JournalSummary = () => {
           </div>
         )}
 
-        {status === 'ready' && user && !loading && !summary && (
+        {!demoMode && status === 'ready' && user && !loading && !summary && (
           <div className="journal-summary__create">
-            {payload?.canCreate ? (
+            {effectivePayload?.canCreate ? (
               <>
                 <p className="journal-summary__lead">
                   Ya puedes crear el resumen de esta semana a partir de tus
@@ -204,18 +223,18 @@ const JournalSummary = () => {
               </>
             ) : (
               <div className="journal-history__empty">
-                {(payload?.entryCount ?? 0) < (payload?.minEntries ?? 2) ? (
+                {(effectivePayload?.entryCount ?? 0) < (effectivePayload?.minEntries ?? 2) ? (
                   <>
                     <p>
-                      Necesitas al menos {payload?.minEntries ?? 2} entradas
+                      Necesitas al menos {effectivePayload?.minEntries ?? 2} entradas
                       esta semana para crear el resumen. Llevas{' '}
-                      {payload?.entryCount ?? 0}.
+                      {effectivePayload?.entryCount ?? 0}.
                     </p>
                     <Link to="/journal" className="journal-history__action-link">
                       Escribir
                     </Link>
                   </>
-                ) : payload?.window?.enforced && !payload?.window?.open ? (
+                ) : effectivePayload?.window?.enforced && !effectivePayload?.window?.open ? (
                   <p>
                     El resumen se puede crear el domingo de 12:00 a 18:00 (hora
                     de Madrid). Mientras tanto, sigue escribiendo.

--- a/frontend/src/Pages/Journal/JournalSummary.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.jsx
@@ -147,6 +147,12 @@ const JournalSummary = () => {
             >
               Escribir
             </Link>
+            <Link
+              to="/journal/history"
+              className="journal-history__write-button journal-history__write-button--header journal-history__write-button--secondary"
+            >
+              Historial
+            </Link>
           </div>
         </header>
 

--- a/frontend/src/Pages/Journal/JournalSummary.test.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.test.jsx
@@ -4,6 +4,7 @@ import JournalSummary from './JournalSummary.jsx';
 import { apiFetch } from '../../api/client.js';
 
 const mockUseAuth = vi.fn();
+const mockUseDemoMode = vi.fn();
 
 vi.mock('react-router-dom', () => ({
   Link: ({ children, to }) => <a href={to}>{children}</a>,
@@ -11,6 +12,10 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('../../Context/AuthContext.jsx', () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('../../Context/DemoModeContext.jsx', () => ({
+  useDemoMode: () => mockUseDemoMode(),
 }));
 
 vi.mock('../../Components/Navigation/Navigation.jsx', () => ({
@@ -23,7 +28,12 @@ vi.mock('../../lib/toastBus.js', () => ({ emitToast: vi.fn() }));
 describe('JournalSummary page states', () => {
   beforeEach(() => {
     mockUseAuth.mockReset();
+    mockUseDemoMode.mockReset();
     apiFetch.mockReset();
+    mockUseDemoMode.mockReturnValue({
+      demoMode: false,
+      toggleDemoMode: vi.fn(),
+    });
   });
 
   afterEach(() => {
@@ -87,5 +97,23 @@ describe('JournalSummary page states', () => {
       expect(screen.getByText(/Nunca es suficiente/i)).toBeTruthy();
       expect(screen.getByText(/Qué prueba tienes/i)).toBeTruthy();
     });
+  });
+
+  test('renders demo summary immediately when demo mode is active', () => {
+    mockUseAuth.mockReturnValue({ user: null, status: 'ready' });
+    mockUseDemoMode.mockReturnValue({
+      demoMode: true,
+      toggleDemoMode: vi.fn(),
+    });
+
+    render(<JournalSummary />);
+
+    expect(
+      screen.getByText(/conviertes la necesidad de control en una virtud/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Maybe I don't need a better plan/i),
+    ).toBeTruthy();
+    expect(apiFetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/data/demoJournal.js
+++ b/frontend/src/data/demoJournal.js
@@ -1,0 +1,93 @@
+export const DEMO_ENTRIES = [
+  {
+    id: 'demo-entry-1',
+    createdAt: '2026-08-02T18:10:00.000Z',
+    topics: ['Reflexión', 'Preocupaciones', 'Trabajo'],
+    content:
+      'Hoy cambiaron una reunión importante con muy poca antelación y sentí el impulso inmediato de reorganizar toda la semana. Hice tres listas distintas y abrí un documento para pensar escenarios posibles, pero al final la conversación ocurrió igual de rápido de lo que iba a ocurrir. Me doy cuenta de que muchas veces no estoy resolviendo el problema, sino intentando sentir que no me puede sorprender.',
+  },
+  {
+    id: 'demo-entry-2',
+    createdAt: '2026-08-01T20:25:00.000Z',
+    topics: ['Sabiduría', 'Reflexión'],
+    content:
+      'Cada vez que algo queda ambiguo, mi reacción es construir estructura alrededor de esa ambigüedad. Lo llamo prudencia y responsabilidad, y en parte lo es, pero también es una forma elegante de no sentirme expuesto. Me cuesta admitir que a veces el orden es menos una herramienta y más un refugio.',
+  },
+  {
+    id: 'demo-entry-3',
+    createdAt: '2026-08-01T08:05:00.000Z',
+    topics: ['Trabajo', 'Preocupaciones'],
+    content:
+      'Pasé buena parte de la mañana investigando opciones para una decisión que, sinceramente, ya podía tomar con la información que tenía ayer. Seguí leyendo porque aprender me calma, pero hay un punto en el que investigar deja de aclarar y empieza a retrasar el momento de decidir. Quizá no estaba buscando comprensión, sino permiso para no moverme todavía.',
+  },
+  {
+    id: 'demo-entry-4',
+    createdAt: '2026-07-31T22:15:00.000Z',
+    topics: ['Interpersonal', 'Reflexión'],
+    content:
+      'Me sorprendió ver lo paciente que soy con la indecisión de otras personas. Puedo entender que alguien cambie de opinión, improvise y se equivoque. Sin embargo, cuando yo hago exactamente eso, la interpretación interna es mucho más dura: debería haberlo previsto, debería haber sabido más, debería haber diseñado un plan mejor.',
+  },
+  {
+    id: 'demo-entry-5',
+    createdAt: '2026-07-31T07:40:00.000Z',
+    topics: ['Sabiduría', 'Trabajo'],
+    content:
+      'Hay una contradicción rara en mi relación con los planes. Digo que planificar me da libertad, pero muchas veces el plan termina diciéndome qué resultados me está permitido aceptar. En cuanto imagino quién debería ser dentro de tres meses, cualquier desviación empieza a sentirse como un fracaso moral en lugar de un ajuste normal.',
+  },
+  {
+    id: 'demo-entry-6',
+    createdAt: '2026-07-30T19:55:00.000Z',
+    topics: ['Reflexión'],
+    content:
+      'Hoy tomé una decisión sin justificarla del todo y el mundo no se cayó. Fue extraño porque no tuve el ritual habitual de argumentos, matrices y escenarios. Simplemente elegí una dirección y seguí con el día. No sé todavía si fue la decisión correcta, pero descubrí que puedo tolerar no saberlo de inmediato.',
+  },
+  {
+    id: 'demo-entry-7',
+    createdAt: '2026-07-30T09:20:00.000Z',
+    topics: ['Preocupaciones', 'Sabiduría'],
+    content:
+      'Empiezo a sospechar que no siempre tengo miedo a equivocarme. A veces me inquieta más pensar que podría haber querido otra cosa, otra vida o incluso otra versión de mí. Ese tipo de incertidumbre no tiene solución técnica. No hay lista que responda por completo a quién debería haber sido.',
+  },
+  {
+    id: 'demo-entry-8',
+    createdAt: '2026-07-29T21:10:00.000Z',
+    topics: ['Trabajo', 'Interpersonal'],
+    content:
+      'Al final ocurrió justo lo que había estado intentando anticipar toda la semana, y la verdad es que mis horas de preparación no cambiaron demasiado el resultado. Lo inquietante es que mi conclusión espontánea no fue relajarme, sino pensar que la próxima vez debería prepararme mejor. Parece lógico, pero también parece una trampa.',
+  },
+  {
+    id: 'demo-entry-9',
+    createdAt: '2026-07-28T18:30:00.000Z',
+    topics: ['Sabiduría', 'Reflexión', 'Meditaciones'],
+    content:
+      "Maybe I don't need a better plan. Maybe I need to become better at moving without one.",
+  },
+  {
+    id: 'demo-entry-10',
+    createdAt: '2026-07-28T07:55:00.000Z',
+    topics: ['Reflexión', 'Preocupaciones'],
+    content:
+      'Sigo funcionando como si primero tuviera que sentirme seguro y solamente después actuar. Pero quizá muchas decisiones importantes funcionan al revés: actúas y la seguridad, si llega, aparece después. Me pregunto cuánto tiempo llevo optimizando una estrategia cuyo objetivo secreto es eliminar una incertidumbre que la vida no piensa eliminar.',
+  },
+];
+
+export const DEMO_SUMMARY_PAYLOAD = {
+  weekStart: '2026-07-27',
+  weekEnd: '2026-08-02',
+  canCreate: false,
+  entryCount: DEMO_ENTRIES.length,
+  minEntries: 2,
+  window: {
+    open: false,
+    enforced: false,
+  },
+  summary: {
+    mainTopics: ['Reflexión', 'Sabiduría', 'Preocupaciones'],
+    summaryText:
+      'Hay algo revelador en cómo conviertes la necesidad de control en una virtud. En varias de tus entradas aparece la misma secuencia: algo escapa a tus manos, y tu primera reacción es construir una estructura alrededor de la incertidumbre. Haces listas, defines escenarios, preparas alternativas. Lo presentas como prudencia. Como responsabilidad. Como estar preparado. Pero hay una pregunta incómoda debajo de todo ese orden: ¿cuánto de esa preparación sirve realmente para resolver problemas y cuánto sirve para no sentirte expuesto a ellos?\n\nLo interesante es que tú mismo detectas el límite. Cuando finalmente ocurre aquello que estabas intentando anticipar, descubres que muchas de las horas dedicadas a prepararte no habían cambiado el resultado. Sin embargo, tu conclusión no es reducir el control, sino perfeccionarlo: preparar mejor, pensar antes, dejar menos cabos sueltos. Es una respuesta perfectamente lógica si tu objetivo es evitar la incertidumbre. Pero quizá ese sea precisamente el problema. Estás optimizando una estrategia cuyo éxito depende de eliminar algo que la vida no parece dispuesta a eliminar.\n\nHay una contradicción más profunda en tu relación con los planes. Dices que planificar te da libertad porque te permite actuar con intención, pero varias de tus reflexiones describen exactamente lo contrario: el plan empieza como herramienta y termina convirtiéndose en obligación. Una vez que has decidido quién deberías ser dentro de tres meses, cualquier desviación empieza a sentirse como fracaso. La estructura que debía darte libertad comienza a dictarte qué resultados tienes permiso para considerar aceptables.\n\nY aquí aparece algo que no parece accidental. Cuando hablas de otras personas, eres mucho más tolerante con su improvisación. Puedes entender que alguien cambie de opinión, que no tenga claro qué quiere, que pruebe algo y se equivoque. Incluso consideras esas cosas signos de inteligencia o flexibilidad. Pero cuando aplicas el mismo criterio a ti mismo, la interpretación cambia: tú deberías haberlo previsto. Tú deberías haber sabido más. Tú deberías haber tenido un plan mejor. La incertidumbre es sabiduría cuando la ves desde fuera y negligencia cuando la experimentas desde dentro.\n\nTambién llama la atención cómo utilizas el conocimiento como mecanismo de seguridad. Cada vez que aparece una duda, tu impulso es investigar. Y aprender es, por supuesto, útil. Pero en tus propias palabras aparece una diferencia entre aprender para comprender y aprender para poder actuar. A veces sigues acumulando información incluso después de tener suficiente para tomar una decisión. En ese punto, la investigación deja de reducir la incertidumbre y empieza simplemente a retrasar el momento en que tienes que convivir con ella.\n\nQuizá por eso la entrada más significativa de la semana no sea aquella en la que encuentras la mejor solución, sino aquella en la que describes haber tomado una decisión sin sentir que necesitabas justificarla completamente. Hay algo casi extraño en el tono: menos argumentos, menos escenarios, menos necesidad de demostrarte que la elección era correcta. Simplemente decidiste. Y después descubriste que podías tolerar no saber todavía si había sido la decisión correcta.\n\nEso introduce una posibilidad que el resto de tus reflexiones apenas considera: quizá no necesitas convertir la incertidumbre en certeza para poder avanzar. Quizá una parte de tu obsesión por prepararte nace de una premisa que nunca has cuestionado: que primero debes sentirte suficientemente seguro y solamente después actuar, cuando muchas decisiones importantes funcionan precisamente al revés. Actúas, y la seguridad aparece después, si aparece.\n\nTu escritura también deja ver algo más sutil. No parece que tengas miedo únicamente de equivocarte. Parece que te incomoda la posibilidad de descubrir que podrías haber elegido algo distinto. El error puede corregirse. La posibilidad de haber querido otra vida, otra dirección o incluso otra versión de ti mismo es más difícil de encajar en tus sistemas porque no tiene una solución técnica. No puedes hacer una lista que responda a quién deberías haber sido.',
+    bestQuote:
+      "Maybe I don't need a better plan. Maybe I need to become better at moving without one.",
+    socraticText:
+      'Si reconoces que gran parte de tu planificación ya no cambia lo que ocurrirá, ¿qué estás intentando conseguir realmente cuando sigues planificando: mejores decisiones o la sensación de estar protegido de las consecuencias de decidir?',
+  },
+};


### PR DESCRIPTION
## Summary

Adds a shared client-side demo mode for the journal History and weekly Summary pages so personal entries can be hidden instantly during demos. When the toggle is on, seeded dummy entries and a matching weekly summary replace real API data; when it is off, the normal authenticated data loads again.

## Changes

### Demo mode state and UI
- Introduces `DemoModeProvider` / `useDemoMode` (in-memory, resets on full refresh) and a reusable `DemoModeToggle` control.
- Places the DEMO toggle next to the page title on both History and Summary, matching the shared header pattern.

### Dummy journal content
- Adds `demoJournal.js` with 10 thematically linked dummy entries and a full weekly summary payload (topics, summary text, best quote, Socratic question).

### History and Summary pages
- History swaps to demo entries immediately, skips the API fetch, hides delete actions and the summary banner while demo mode is active.
- Summary swaps to the demo payload immediately and skips the current-summary API call while demo mode is active.
- Summary header now mirrors History: title + DEMO on the top row, with `Escribir` and `Historial` actions underneath.
- Prevents the summary title from wrapping next to the DEMO toggle (`flex-shrink: 0` / `white-space: nowrap`).

### Tests
- Adds History coverage for demo-mode rendering without API calls.
- Extends Summary tests to assert demo summary content appears when demo mode is on.

## Notes
- Demo mode is session-only (no `localStorage`); a full page refresh turns it off.
- Dummy data never leaves the client; no backend changes.
- Branch: `feature/journal-demo-mode` (2 commits on top of `main`).

## Test plan
- [ ] On `/journal/history`, confirm DEMO is next to “Historial”; toggling ON shows the 10 dummy entries and hides trash icons.
- [ ] Navigate to `/journal/summary` with demo mode still ON; confirm the dummy weekly summary appears without a loading/create state.
- [ ] Toggle DEMO OFF on Summary; confirm real (or empty/login) summary state returns.
- [ ] Toggle DEMO ON again from Summary; confirm History also shows dummy data when returning via `Historial`.
- [ ] Confirm Summary header layout matches History (title + DEMO, then `Escribir` / `Historial`), and “Resumen semanal” stays on one line.
- [ ] Hard-refresh the page; confirm demo mode is off and real data (or guest prompts) show again.