### PR TITLE
Chore: polish interface

### DIFF
--- a/frontend/src/Components/ScrollToTop/ScrollToTop.jsx
+++ b/frontend/src/Components/ScrollToTop/ScrollToTop.jsx
@@ -1,12 +1,38 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { matchPath, useLocation } from 'react-router-dom';
 
-export default function ScrollToTop() {
+const scrollPolicies = [
+    { path: '/journal', scroll: 'bottom' },
+];
+
+const getScroll = (pathname) => {
+    const matchedPolicy = scrollPolicies.find(({ path }) =>
+        matchPath({ path, end: true }, pathname)
+    );
+
+    return matchedPolicy?.scroll ?? 'top';
+};
+
+const ScrollToTop = () => {
     const { pathname, search } = useLocation();
+    const scroll = getScroll(pathname);
 
     useEffect(() => {
+        if (scroll === 'bottom') {
+            const frameId = window.requestAnimationFrame(() => {
+                window.scrollTo(0, document.documentElement.scrollHeight);
+            });
+
+            return () => {
+                window.cancelAnimationFrame(frameId);
+            };
+        }
+
         window.scrollTo(0, 0);
-    }, [pathname, search]);
+        return undefined;
+    }, [pathname, scroll, search]);
 
     return null;
-}
+};
+
+export default ScrollToTop;

--- a/frontend/src/Components/ScrollToTop/ScrollToTop.test.jsx
+++ b/frontend/src/Components/ScrollToTop/ScrollToTop.test.jsx
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import ScrollToTop from './ScrollToTop.jsx';
+
+const mockUseLocation = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+
+  return {
+    ...actual,
+    useLocation: () => mockUseLocation(),
+  };
+});
+
+describe('ScrollToTop', () => {
+  beforeEach(() => {
+    mockUseLocation.mockReturnValue({ pathname: '/test', search: '' });
+
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback();
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  test('scrolls to the top by default', () => {
+    render(<ScrollToTop />);
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  test('scrolls to the bottom when the route opts in', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/journal', search: '' });
+
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      configurable: true,
+      value: 1234,
+    });
+
+    render(<ScrollToTop />);
+
+    expect(window.requestAnimationFrame).toHaveBeenCalled();
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 1234);
+  });
+});

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -12,7 +12,7 @@
   flex-direction: column;
   width: min(100%, 640px);
   margin: 0 auto;
-  padding: 96px 20px 120px;
+  padding: 96px 20px 60px;
   box-sizing: border-box;
 }
 
@@ -472,7 +472,7 @@
   line-height: 1.5;
   color: var(--text);
   white-space: pre-wrap;
-  font-size: 17px;
+  font-size: 16px;
 }
 
 .journal-history__excerpt--toggleable {

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -44,6 +44,9 @@
 }
 
 .journal-page__topics {
+  --topics-fade-left: #000;
+  --topics-fade-right: #000;
+  --topics-fade-size: 28px;
   display: grid;
   grid-template-rows: repeat(2, auto);
   grid-template-columns: repeat(var(--topic-cols, 3), max-content);
@@ -55,6 +58,28 @@
   overscroll-behavior-x: contain;
   scrollbar-width: none;
   scrollbar-color: color-mix(in srgb, var(--accent) 35%, transparent) transparent;
+  -webkit-mask-image: linear-gradient(
+    to right,
+    var(--topics-fade-left) 0,
+    #000 var(--topics-fade-size),
+    #000 calc(100% - var(--topics-fade-size)),
+    var(--topics-fade-right) 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    var(--topics-fade-left) 0,
+    #000 var(--topics-fade-size),
+    #000 calc(100% - var(--topics-fade-size)),
+    var(--topics-fade-right) 100%
+  );
+}
+
+.journal-page__topics--fade-left {
+  --topics-fade-left: transparent;
+}
+
+.journal-page__topics--fade-right {
+  --topics-fade-right: transparent;
 }
 
 .journal-page__topics::-webkit-scrollbar {
@@ -83,6 +108,7 @@
   font-size: 0.875rem;
   font-weight: 600;
   line-height: 1.3;
+  margin-bottom: 2px;
   cursor: pointer;
 }
 

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -598,6 +598,21 @@
   color: var(--accent);
 }
 
+.journal-summary__heading--socratic {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.journal-summary__avatar {
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  object-position: center top;
+}
+
 .journal-summary__body,
 .journal-summary__socratic {
   margin: 0;

--- a/frontend/src/Pages/Journal/Journal.jsx
+++ b/frontend/src/Pages/Journal/Journal.jsx
@@ -10,6 +10,7 @@ import {
   prepareImageForUpload,
   MAX_UPLOAD_BYTES,
 } from './journalImage.js';
+import { getTopicsFadeEdges } from './journalTopicsFade.js';
 import JournalSummaryBanner from './JournalSummaryBanner.jsx';
 import './Journal.css';
 
@@ -30,6 +31,7 @@ const Journal = () => {
   const { user, status } = useAuth();
   const textareaRef = useRef(null);
   const fileInputRef = useRef(null);
+  const topicsRef = useRef(null);
   const [text, setText] = useState('');
   const [selectedTopics, setSelectedTopics] = useState([]);
   const [saving, setSaving] = useState(false);
@@ -37,6 +39,7 @@ const Journal = () => {
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState('');
   const [transcribing, setTranscribing] = useState(false);
+  const [fadeEdges, setFadeEdges] = useState({ left: false, right: false });
 
   const canUseImages = status === 'ready' && !!user;
   const busy = saving || transcribing;
@@ -49,9 +52,28 @@ const Journal = () => {
     el.style.height = `${el.scrollHeight}px`;
   };
 
+  const updateFadeEdges = () => {
+    const el = topicsRef.current;
+    if (!el) return;
+    const next = getTopicsFadeEdges(el);
+    setFadeEdges((prev) =>
+      prev.left === next.left && prev.right === next.right ? prev : next
+    );
+  };
+
   useEffect(() => {
     resizeTextarea();
   }, [text]);
+
+  useEffect(() => {
+    const el = topicsRef.current;
+    if (!el) return undefined;
+
+    updateFadeEdges();
+    const resizeObserver = new ResizeObserver(updateFadeEdges);
+    resizeObserver.observe(el);
+    return () => resizeObserver.disconnect();
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -188,7 +210,11 @@ const Journal = () => {
 
         <div className="journal-page__composer">
           <div
-            className="journal-page__topics"
+            ref={topicsRef}
+            onScroll={updateFadeEdges}
+            className={`journal-page__topics${
+              fadeEdges.left ? ' journal-page__topics--fade-left' : ''
+            }${fadeEdges.right ? ' journal-page__topics--fade-right' : ''}`}
             role="group"
             aria-label="Temas del diario"
             style={{

--- a/frontend/src/Pages/Journal/Journal.test.jsx
+++ b/frontend/src/Pages/Journal/Journal.test.jsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import Journal from './Journal.jsx';
 
 const mockUseAuth = vi.fn();
@@ -24,9 +24,29 @@ vi.mock('../../Components/CloseIcon/CloseIcon.jsx', () => ({
 vi.mock('../../api/client.js', () => ({ apiFetch: vi.fn() }));
 vi.mock('../../lib/toastBus.js', () => ({ emitToast: vi.fn() }));
 
+const mockScrollMetrics = (el, { scrollLeft, clientWidth, scrollWidth }) => {
+  Object.defineProperty(el, 'scrollLeft', {
+    configurable: true,
+    get: () => scrollLeft,
+  });
+  Object.defineProperty(el, 'clientWidth', {
+    configurable: true,
+    get: () => clientWidth,
+  });
+  Object.defineProperty(el, 'scrollWidth', {
+    configurable: true,
+    get: () => scrollWidth,
+  });
+};
+
 describe('Journal handwriting capture gating', () => {
   beforeEach(() => {
     mockUseAuth.mockReset();
+    global.ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    };
   });
 
   afterEach(() => {
@@ -49,5 +69,52 @@ describe('Journal handwriting capture gating', () => {
     mockUseAuth.mockReturnValue({ user: null, status: 'loading' });
     render(<Journal />);
     expect(screen.queryByRole('button', { name: /Escanear/i })).toBeNull();
+  });
+});
+
+describe('Journal topic edge fade', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ user: null, status: 'ready' });
+    global.ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('toggles fade classes from scroll overflow', () => {
+    render(<Journal />);
+    const topics = screen.getByRole('group', { name: 'Temas del diario' });
+
+    mockScrollMetrics(topics, {
+      scrollLeft: 0,
+      clientWidth: 320,
+      scrollWidth: 480,
+    });
+    fireEvent.scroll(topics);
+    expect(topics.className).toContain('journal-page__topics--fade-right');
+    expect(topics.className).not.toContain('journal-page__topics--fade-left');
+
+    mockScrollMetrics(topics, {
+      scrollLeft: 80,
+      clientWidth: 320,
+      scrollWidth: 480,
+    });
+    fireEvent.scroll(topics);
+    expect(topics.className).toContain('journal-page__topics--fade-left');
+    expect(topics.className).toContain('journal-page__topics--fade-right');
+
+    mockScrollMetrics(topics, {
+      scrollLeft: 160,
+      clientWidth: 320,
+      scrollWidth: 480,
+    });
+    fireEvent.scroll(topics);
+    expect(topics.className).toContain('journal-page__topics--fade-left');
+    expect(topics.className).not.toContain('journal-page__topics--fade-right');
   });
 });

--- a/frontend/src/Pages/Journal/JournalSummary.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.jsx
@@ -180,7 +180,14 @@ const JournalSummary = () => {
             </section>
 
             <section className="journal-summary__section">
-              <h2 className="journal-summary__heading">Pregunta de Sócrates</h2>
+              <h2 className="journal-summary__heading journal-summary__heading--socratic">
+                <img
+                  src="/images/socrates.webp"
+                  alt="Sócrates"
+                  className="journal-summary__avatar"
+                />
+                Pregunta de Sócrates
+              </h2>
               <p className="journal-summary__socratic">{summary.socraticText}</p>
             </section>
           </div>

--- a/frontend/src/Pages/Journal/JournalSummary.test.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.test.jsx
@@ -86,6 +86,9 @@ describe('JournalSummary page states', () => {
       expect(screen.getByText(/Escribiste sobre el trabajo/i)).toBeTruthy();
       expect(screen.getByText(/Nunca es suficiente/i)).toBeTruthy();
       expect(screen.getByText(/Qué prueba tienes/i)).toBeTruthy();
+      expect(screen.getByRole('heading', { name: /Pregunta de Sócrates/i })).toBeTruthy();
+      const avatar = screen.getByAltText('Sócrates');
+      expect(avatar.getAttribute('src')).toBe('/images/socrates.webp');
     });
   });
 });

--- a/frontend/src/Pages/Journal/journalTopicsFade.js
+++ b/frontend/src/Pages/Journal/journalTopicsFade.js
@@ -1,0 +1,7 @@
+const TOPICS_FADE_TOLERANCE_PX = 1;
+
+/** Decide which topic-row edges should fade based on horizontal scroll overflow. */
+export const getTopicsFadeEdges = ({ scrollLeft, clientWidth, scrollWidth }) => ({
+  left: scrollLeft > TOPICS_FADE_TOLERANCE_PX,
+  right: scrollLeft + clientWidth < scrollWidth - TOPICS_FADE_TOLERANCE_PX,
+});

--- a/frontend/src/Pages/Journal/journalTopicsFade.test.js
+++ b/frontend/src/Pages/Journal/journalTopicsFade.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import { getTopicsFadeEdges } from './journalTopicsFade.js';
+
+describe('getTopicsFadeEdges', () => {
+  test('shows no fades when content fits', () => {
+    expect(
+      getTopicsFadeEdges({ scrollLeft: 0, clientWidth: 320, scrollWidth: 320 })
+    ).toEqual({ left: false, right: false });
+  });
+
+  test('shows only the right fade at the start of an overflowing row', () => {
+    expect(
+      getTopicsFadeEdges({ scrollLeft: 0, clientWidth: 320, scrollWidth: 480 })
+    ).toEqual({ left: false, right: true });
+  });
+
+  test('shows both fades while scrolled in the middle', () => {
+    expect(
+      getTopicsFadeEdges({ scrollLeft: 80, clientWidth: 320, scrollWidth: 480 })
+    ).toEqual({ left: true, right: true });
+  });
+
+  test('shows only the left fade at the end of an overflowing row', () => {
+    expect(
+      getTopicsFadeEdges({ scrollLeft: 160, clientWidth: 320, scrollWidth: 480 })
+    ).toEqual({ left: true, right: false });
+  });
+});


### PR DESCRIPTION
## Summary

Polishes the journal experience with better scroll behavior on the composer, clearer overflow cues on topic chips, and a Socrates avatar on the weekly summary’s Socratic question.

## Changes

### Journal composer scroll
- Route-aware scroll policy so `/journal` opens scrolled to the bottom (composer in view) instead of the top; other routes still scroll to top.

### Topic chips overflow fade
- Conditionally fades left/right edges of the horizontal topics row when content overflows, updating on scroll and resize.

### Journal summary Socrates avatar
- Shows a circular Socrates image beside “Pregunta de Sócrates,” matching the existing Tales avatar sizing from onboarding.

## Notes
- Scroll behavior is driven by a small path policy list in `ScrollToTop` (`/journal` → bottom; default → top).
- Topic fade logic lives in `journalTopicsFade.js` for easy unit testing.

## Test plan
- [ ] Open `/journal` (including via in-app navigation) and confirm the page lands at the bottom near the composer.
- [ ] Navigate away from `/journal` and confirm other pages still scroll to the top.
- [ ] On the journal composer, with overflowing topic chips, confirm right fade appears; scroll horizontally and confirm left/right fades update correctly.
- [ ] With few topics (no overflow), confirm no edge fades.
- [ ] Open a weekly summary that includes a Socratic question and confirm the circular Socrates image appears left of the heading.