### PR TITLE
Chore: correct minor issues

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -124,3 +124,18 @@ Generate the weekly journal reflection **on user click** during a limited Sunday
 
 **What would trigger revisiting:**  
 Persistent timeouts, desire for push/email reminders, or a multi-week archive/compare product surface.
+### 2026-08-09 — Summary create gating moved to the SPA; POST upserts
+
+**Decision:**  
+`GET /auth/me/journal-summaries/current` returns raw `summary` + `window` + `entryCount`. The SPA derives create availability (including hiding summaries with `createdAt < window.opensAt` while the window is open). `POST /current` no longer returns `403`/`409`; it generates from the week’s entries and **upserts** (refreshing `created_at`). A temporary **Regenerar** button on the summary page calls the same POST for testing.
+
+**Why this option was chosen:**  
+- Mid-week test regenerations must not block the next Sunday create CTA.
+- One POST path for create and regenerate keeps the backend a pure generator.
+- Removing the Regenerar button later restores one-create-per-window UX without backend changes.
+
+**Why this revisits 2026-08-01:**  
+That decision required server-side window enforcement and rejected free regenerate. Product/testing needs temporarily override that; the SPA still presents the Sunday ritual. Re-add server `403`/`409` if abuse or cost becomes a problem.
+
+**Operational implications (accepted):**  
+An authenticated client can call POST outside the window (cost/abuse surface). Acceptable while Regenerar exists for testing.

--- a/backend/src/journalSummaries/journalSummaries.controller.js
+++ b/backend/src/journalSummaries/journalSummaries.controller.js
@@ -1,19 +1,15 @@
 import {
   buildWindowPayload,
   getWeekBounds,
-  isSummaryWindowOpen,
   MIN_ENTRIES_FOR_SUMMARY,
 } from './summaryWindow.js';
 import {
-  countJournalEntriesInRange,
-  createWeeklySummary,
-  getWeeklySummaryForUser,
   listJournalEntriesInRange,
+  countJournalEntriesInRange,
+  getWeeklySummaryForUser,
+  upsertWeeklySummary,
 } from './journalSummaries.service.js';
 import { generateWeeklySummaryContent } from './journalSummaries.generation.js';
-
-const uniqueViolation = (err) =>
-  err?.code === '23505' || /duplicate key/i.test(String(err?.message ?? ''));
 
 const buildCurrentPayload = async (userId, now = new Date()) => {
   const bounds = getWeekBounds(now);
@@ -23,18 +19,12 @@ const buildCurrentPayload = async (userId, now = new Date()) => {
     getWeeklySummaryForUser(userId, bounds.weekStart),
   ]);
 
-  const canCreate =
-    window.open &&
-    !summary &&
-    entryCount >= MIN_ENTRIES_FOR_SUMMARY;
-
   return {
     weekStart: bounds.weekStart,
     weekEnd: bounds.weekEnd,
     window,
     entryCount,
     minEntries: MIN_ENTRIES_FOR_SUMMARY,
-    canCreate,
     summary,
   };
 };
@@ -52,24 +42,7 @@ export const getCurrentJournalSummary = async (req, res) => {
 export const postCurrentJournalSummary = async (req, res) => {
   try {
     const now = new Date();
-    if (!isSummaryWindowOpen(now)) {
-      return res.status(403).json({
-        message:
-          'El resumen semanal solo se puede crear el domingo de 12:00 a 18:00 (hora de Madrid).',
-      });
-    }
-
     const bounds = getWeekBounds(now);
-    const existing = await getWeeklySummaryForUser(
-      req.user.id,
-      bounds.weekStart,
-    );
-    if (existing) {
-      return res.status(409).json({
-        message: 'Ya existe un resumen para esta semana.',
-        summary: existing,
-      });
-    }
 
     const entries = await listJournalEntriesInRange(
       req.user.id,
@@ -105,36 +78,22 @@ export const postCurrentJournalSummary = async (req, res) => {
       });
     }
 
-    try {
-      const summary = await createWeeklySummary({
-        userId: req.user.id,
-        weekStart: bounds.weekStart,
-        weekEnd: bounds.weekEnd,
-        periodStart: bounds.periodStart,
-        periodEnd: bounds.periodEnd,
-        summaryText: generated.summaryText,
-        mainTopics: generated.mainTopics,
-        bestQuote: generated.bestQuote,
-        bestQuoteEntryId: generated.bestQuoteEntryId,
-        socraticText: generated.socraticText,
-        machiavelliText: generated.machiavelliText,
-        entryCount: entries.length,
-        modelId: generated.modelId,
-      });
-      return res.status(201).json({ summary });
-    } catch (insertErr) {
-      if (uniqueViolation(insertErr)) {
-        const summary = await getWeeklySummaryForUser(
-          req.user.id,
-          bounds.weekStart,
-        );
-        return res.status(409).json({
-          message: 'Ya existe un resumen para esta semana.',
-          summary,
-        });
-      }
-      throw insertErr;
-    }
+    const summary = await upsertWeeklySummary({
+      userId: req.user.id,
+      weekStart: bounds.weekStart,
+      weekEnd: bounds.weekEnd,
+      periodStart: bounds.periodStart,
+      periodEnd: bounds.periodEnd,
+      summaryText: generated.summaryText,
+      mainTopics: generated.mainTopics,
+      bestQuote: generated.bestQuote,
+      bestQuoteEntryId: generated.bestQuoteEntryId,
+      socraticText: generated.socraticText,
+      machiavelliText: generated.machiavelliText,
+      entryCount: entries.length,
+      modelId: generated.modelId,
+    });
+    return res.status(201).json({ summary });
   } catch (err) {
     console.error('[journal-summaries POST current]', err);
     return res.status(500).json({ message: 'Error al crear el resumen.' });

--- a/backend/src/journalSummaries/journalSummaries.service.js
+++ b/backend/src/journalSummaries/journalSummaries.service.js
@@ -116,3 +116,60 @@ export const createWeeklySummary = async ({
   );
   return mapSummaryRow(rows[0]);
 };
+
+/** Insert or replace the week's summary. Always refreshes created_at. */
+export const upsertWeeklySummary = async ({
+  userId,
+  weekStart,
+  weekEnd,
+  periodStart,
+  periodEnd,
+  summaryText,
+  mainTopics,
+  bestQuote,
+  bestQuoteEntryId,
+  socraticText,
+  machiavelliText,
+  entryCount,
+  modelId,
+}) => {
+  const { rows } = await pool.query(
+    `INSERT INTO journal_weekly_summaries (
+       user_id, week_start, week_end, period_start, period_end,
+       summary_text, main_topics, best_quote, best_quote_entry_id,
+       socratic_text, machiavelli_text, entry_count, model_id
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+     ON CONFLICT (user_id, week_start) DO UPDATE SET
+       week_end = EXCLUDED.week_end,
+       period_start = EXCLUDED.period_start,
+       period_end = EXCLUDED.period_end,
+       summary_text = EXCLUDED.summary_text,
+       main_topics = EXCLUDED.main_topics,
+       best_quote = EXCLUDED.best_quote,
+       best_quote_entry_id = EXCLUDED.best_quote_entry_id,
+       socratic_text = EXCLUDED.socratic_text,
+       machiavelli_text = EXCLUDED.machiavelli_text,
+       entry_count = EXCLUDED.entry_count,
+       model_id = EXCLUDED.model_id,
+       created_at = NOW()
+     RETURNING id, user_id, week_start, week_end, period_start, period_end,
+               summary_text, main_topics, best_quote, best_quote_entry_id,
+               socratic_text, machiavelli_text, entry_count, model_id, created_at`,
+    [
+      userId,
+      weekStart,
+      weekEnd,
+      periodStart,
+      periodEnd,
+      summaryText,
+      mainTopics,
+      bestQuote,
+      bestQuoteEntryId,
+      socraticText,
+      machiavelliText,
+      entryCount,
+      modelId,
+    ],
+  );
+  return mapSummaryRow(rows[0]);
+};

--- a/backend/src/journalSummaries/summaryWindow.js
+++ b/backend/src/journalSummaries/summaryWindow.js
@@ -7,9 +7,8 @@
 export const SUMMARY_TIMEZONE = 'Europe/Madrid';
 export const MIN_ENTRIES_FOR_SUMMARY = 2;
 
-// TEMP for local/dev testing: keep false so creation is not Sunday-gated.
-// Set to true before shipping the Sunday ritual.
-export const ENFORCE_SUMMARY_WINDOW = false;
+/** When true, creation window is Sunday 12:00–18:00 Europe/Madrid. */
+export const ENFORCE_SUMMARY_WINDOW = true;
 
 const WINDOW_START_HOUR = 12;
 const WINDOW_END_HOUR = 18;

--- a/backend/src/journalSummaries/summaryWindow.test.js
+++ b/backend/src/journalSummaries/summaryWindow.test.js
@@ -39,8 +39,7 @@ test('getZonedParts reports Sunday in Madrid for window open instant', () => {
   assert.equal(parts.hour, 12);
 });
 
-test('isSummaryWindowOpen respects ENFORCE_SUMMARY_WINDOW bypass', () => {
-  // A random Wednesday — when enforcement is off (current default), open is true.
+test('isSummaryWindowOpen respects ENFORCE_SUMMARY_WINDOW', () => {
   const wednesday = new Date('2026-07-29T13:00:00.000Z');
   if (!ENFORCE_SUMMARY_WINDOW) {
     assert.equal(isSummaryWindowOpen(wednesday), true);

--- a/docs/weekly-journal-summary.md
+++ b/docs/weekly-journal-summary.md
@@ -142,7 +142,9 @@ Mount next to existing journal routes in `backend/src/auth/auth.routes.js`.
 
 ### `GET /auth/me/journal-summaries/current`
 
-Returns window + week metadata + summary if present.
+Returns window + week metadata + summary if present. Creation gating is
+computed on the frontend from this payload (see
+`frontend/src/Pages/Journal/summaryAvailability.js`).
 
 ```json
 {
@@ -151,25 +153,32 @@ Returns window + week metadata + summary if present.
   "window": {
     "timezone": "Europe/Madrid",
     "open": true,
+    "enforced": true,
     "opensAt": "2026-08-02T10:00:00.000Z",
     "closesAt": "2026-08-02T16:00:00.000Z"
   },
   "entryCount": 5,
-  "canCreate": true,
+  "minEntries": 2,
   "summary": null
 }
 ```
 
-`canCreate` = authenticated + window open + no existing summary + `entryCount > 0`.
+Frontend `canCreate` = window open + no displayed (non-stale) summary +
+`entryCount >= minEntries`. A summary is stale when `createdAt < window.opensAt`
+while the window is open (hidden so a new week’s create CTA can appear).
 
 ### `POST /auth/me/journal-summaries/current`
 
 - Requires auth
-- Server recomputes week + window (never trust client clock alone for authorization)
+- Server recomputes week bounds from the current time
 - Loads entries in `[period_start, period_end)`
-- Calls model, validates JSON, inserts row
-- Returns the created summary
-- Conflicts: `409` if already exists; `403` if outside window; `422` if no entries
+- Calls model, validates JSON, upserts the row for `(user_id, week_start)`
+  (replaces any existing summary; refreshes `created_at`)
+- Returns the created/updated summary
+- Errors: `422` if fewer than `minEntries` entries; `502`/`503` on generation
+  failures
+- Does **not** enforce the Sunday window or reject an existing summary —
+  the SPA decides when to show Create vs Regenerate
 
 ### Optional later
 
@@ -222,7 +231,7 @@ Also pass entry ids + timestamps so the backend can optionally attach `best_quot
 | Route | `/journal/summary` in `App.jsx` beside existing journal routes |
 | Page | `frontend/src/Pages/Journal/JournalSummary.jsx` (+ CSS in `Journal.css` or sibling) |
 | Loading | Adapt `TestLoadingScreen` pattern: progress + reflective quote, but `onDone` waits for **real** `POST` (or `Promise.all` of min display time + request) |
-| CTA / alert | Banner on `/journal` and/or `/journal/history` when `window.open && canCreate`; optionally subtle nav hint |
+| CTA / alert | Banner on `/journal` when frontend `canCreate` (window open, non-stale, enough entries) |
 | Result layout | Four stacked sections (not a dashboard of cards): Summary → Best quote → Socratic prompt → Machiavellian challenge |
 | History link | From journal header area: “Resumen” next to “Escribir” / history patterns |
 
@@ -245,7 +254,7 @@ Closest existing pattern: client date gate in `promoConfig.js` / `PromoGate` —
 
 Build in thin vertical slices; each slice shippable alone.
 
-1. **Window + status API** — `GET current` with `open` / `entryCount` / `canCreate`; no LLM yet.
+1. **Window + status API** — `GET current` with `open` / `entryCount` / `summary`; frontend derives create availability.
 2. **Summary page shell + CTA banner** — wired to GET; empty / closed / ready states.
 3. **Persistence + POST without LLM** — stubbed summary text for local/dev to prove uniqueness + UX.
 4. **Real LLM generation** — prompt, parse, store, loading screen tied to request.
@@ -263,22 +272,26 @@ Build in thin vertical slices; each slice shippable alone.
 
 1. **Window:** Sunday 12:00–18:00, `Europe/Madrid`.
 2. **Missed Sunday:** No late creation. Summaries remain **readable anytime** after they exist.
-3. **Regeneration:** Never once stored. **Retry only when generation fails** (no row written).
+3. **Regeneration:** Temporary testing `REGENERAR RESUMEN` button on the summary
+   page calls the same `POST /current` (upsert). Remove that button to restore
+   one-create-per-window UX. Retry still applies when generation fails (no row).
 4. **Minimum writing:** At least **2 entries** in the week. No minimum character count.
 5. **Access:** All logged-in users (same as journal today).
 6. **Socratic tone:** Sharper / challenging (tunable later).
 7. **Machiavellian tone:** Practical and strategic; challenge the user's incentives without recommending manipulation.
 8. **Copy language:** Spanish UI + Spanish prompts for v1.
 
-### Dev bypass
+### Window enforcement
 
-`ENFORCE_SUMMARY_WINDOW` in `backend/src/journalSummaries/summaryWindow.js` is **`false`** while developing so creation can be tested any day. Set it to `true` before shipping the Sunday ritual.
-
+`ENFORCE_SUMMARY_WINDOW` in `backend/src/journalSummaries/summaryWindow.js` is
+**`true`**. The SPA uses `window.open` / `window.opensAt` for create CTA and
+stale-summary hiding. The POST endpoint does not re-check the clock.
 ## 14. Success criteria
 
 - Users who write during the week have a clear Sunday ritual that returns value from their own words.
 - Summary feels personal (topics + quote from *their* text), not generic wellness filler.
 - Socratic section produces a question the user could actually journal about next.
 - Machiavellian section exposes whether the user's strategy supports their stated goal.
-- Creation cannot be spammed (one per week; window enforced server-side).
+- Creation cannot be spammed from the product UI (one create CTA per Sunday
+  window; temporary regenerate is explicit for testing).
 - Experience stays within the 20s serverless budget for typical weekly volume.

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -12,17 +12,13 @@
   flex-direction: column;
   width: min(100%, 640px);
   margin: 0 auto;
-  padding: 96px 20px 60px;
+  padding: 30px 20px 60px;
   box-sizing: border-box;
 }
 
 .journal-page__main--history {
   justify-content: flex-start;
   gap: 24px;
-}
-
-.journal-page--history .journal-page__main {
-  padding-top: 30px;
 }
 
 .journal-page__prompt {

--- a/frontend/src/Pages/Journal/Journal.css
+++ b/frontend/src/Pages/Journal/Journal.css
@@ -180,6 +180,15 @@
   cursor: not-allowed;
 }
 
+.journal-page__complete-button--secondary {
+  background: var(--background);
+  color: var(--accent);
+}
+
+.journal-summary__regenerate {
+  margin-top: 32px;
+}
+
 .journal-page__history-link {
   display: block;
   text-align: center;

--- a/frontend/src/Pages/Journal/JournalSummary.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.jsx
@@ -211,7 +211,7 @@ const JournalSummary = () => {
                   alt="Sócrates"
                   className="journal-summary__avatar"
                 />
-                Pregunta de Sócrates
+                Pregunta Socrática
               </h2>
               <p className="journal-summary__socratic">{summary.socraticText}</p>
             </section>

--- a/frontend/src/Pages/Journal/JournalSummary.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.jsx
@@ -8,6 +8,7 @@ import { apiFetch } from '../../api/client.js';
 import { DEMO_SUMMARY_PAYLOAD } from '../../data/demoJournal.js';
 import { emitToast } from '../../lib/toastBus.js';
 import JournalSummaryLoadingScreen from './JournalSummaryLoadingScreen.jsx';
+import { resolveSummaryAvailability } from './summaryAvailability.js';
 import './Journal.css';
 
 const formatWeekLabel = (weekStart, weekEnd) => {
@@ -67,8 +68,8 @@ const JournalSummary = () => {
     loadCurrent();
   }, [loadCurrent]);
 
-  const handleCreate = async () => {
-    if (generating || !payload?.canCreate) return;
+  const handleGenerate = async () => {
+    if (generating) return;
 
     setGenerating(true);
     setGenerateReady(false);
@@ -90,7 +91,6 @@ const JournalSummary = () => {
       setGenerateReady(false);
       setPendingSummary(null);
       emitToast(err.message || 'No se pudo crear el resumen.');
-      // Refresh so canCreate / existing summary stay accurate after a race.
       loadCurrent();
     }
   };
@@ -102,7 +102,6 @@ const JournalSummary = () => {
           ? {
               ...prev,
               summary: pendingSummary,
-              canCreate: false,
             }
           : prev,
       );
@@ -125,7 +124,8 @@ const JournalSummary = () => {
   }
 
   const effectivePayload = demoMode ? DEMO_SUMMARY_PAYLOAD : payload;
-  const summary = effectivePayload?.summary;
+  const availability = resolveSummaryAvailability(effectivePayload);
+  const summary = availability.displayedSummary;
   const weekLabel = formatWeekLabel(
     effectivePayload?.weekStart,
     effectivePayload?.weekEnd,
@@ -211,7 +211,7 @@ const JournalSummary = () => {
                   alt="Sócrates"
                   className="journal-summary__avatar"
                 />
-                Pregunta Socrática
+                Pregunta de Sócrates
               </h2>
               <p className="journal-summary__socratic">{summary.socraticText}</p>
             </section>
@@ -231,12 +231,24 @@ const JournalSummary = () => {
                 </p>
               </section>
             )}
+
+            {!demoMode && (
+              <div className="journal-summary__regenerate">
+                <button
+                  type="button"
+                  className="journal-page__complete-button journal-page__complete-button--secondary"
+                  onClick={handleGenerate}
+                >
+                  REGENERAR RESUMEN
+                </button>
+              </div>
+            )}
           </div>
         )}
 
         {!demoMode && status === 'ready' && user && !loading && !summary && (
           <div className="journal-summary__create">
-            {effectivePayload?.canCreate ? (
+            {availability.canCreate ? (
               <>
                 <p className="journal-summary__lead">
                   Ya puedes crear el resumen de esta semana a partir de tus
@@ -245,25 +257,25 @@ const JournalSummary = () => {
                 <button
                   type="button"
                   className="journal-page__complete-button"
-                  onClick={handleCreate}
+                  onClick={handleGenerate}
                 >
                   CREAR RESUMEN
                 </button>
               </>
             ) : (
               <div className="journal-history__empty">
-                {(effectivePayload?.entryCount ?? 0) < (effectivePayload?.minEntries ?? 2) ? (
+                {availability.entryCount < availability.minEntries ? (
                   <>
                     <p>
-                      Necesitas al menos {effectivePayload?.minEntries ?? 2} entradas
+                      Necesitas al menos {availability.minEntries} entradas
                       esta semana para crear el resumen. Llevas{' '}
-                      {effectivePayload?.entryCount ?? 0}.
+                      {availability.entryCount}.
                     </p>
                     <Link to="/journal" className="journal-history__action-link">
                       Escribir
                     </Link>
                   </>
-                ) : effectivePayload?.window?.enforced && !effectivePayload?.window?.open ? (
+                ) : availability.windowEnforced && !availability.windowOpen ? (
                   <p>
                     El resumen se puede crear el domingo de 12:00 a 18:00 (hora
                     de Madrid). Mientras tanto, sigue escribiendo.

--- a/frontend/src/Pages/Journal/JournalSummary.test.jsx
+++ b/frontend/src/Pages/Journal/JournalSummary.test.jsx
@@ -48,17 +48,21 @@ describe('JournalSummary page states', () => {
     ).toBeTruthy();
   });
 
-  test('shows create CTA when canCreate is true', async () => {
+  test('shows create CTA when the window is open and there is no summary', async () => {
     mockUseAuth.mockReturnValue({ user: { id: 'u1' }, status: 'ready' });
     apiFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
         weekStart: '2026-07-27',
         weekEnd: '2026-08-02',
-        window: { open: true, enforced: false },
+        window: {
+          open: true,
+          enforced: true,
+          opensAt: '2026-08-02T10:00:00.000Z',
+          closesAt: '2026-08-02T16:00:00.000Z',
+        },
         entryCount: 3,
         minEntries: 2,
-        canCreate: true,
         summary: null,
       }),
     });
@@ -71,17 +75,55 @@ describe('JournalSummary page states', () => {
     });
   });
 
-  test('renders stored summary sections', async () => {
+  test('shows create CTA when the only summary is stale for this window', async () => {
     mockUseAuth.mockReturnValue({ user: { id: 'u1' }, status: 'ready' });
     apiFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
         weekStart: '2026-07-27',
         weekEnd: '2026-08-02',
-        window: { open: true, enforced: false },
+        window: {
+          open: true,
+          enforced: true,
+          opensAt: '2026-08-02T10:00:00.000Z',
+          closesAt: '2026-08-02T16:00:00.000Z',
+        },
         entryCount: 3,
         minEntries: 2,
-        canCreate: false,
+        summary: {
+          summaryText: 'Resumen de mitad de semana',
+          createdAt: '2026-07-29T12:00:00.000Z',
+          mainTopics: ['Trabajo'],
+          bestQuote: 'Nunca es suficiente',
+          socraticText: '¿Qué prueba tienes de eso?',
+        },
+      }),
+    });
+
+    render(<JournalSummary />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /CREAR RESUMEN/i }),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText(/Resumen de mitad de semana/i)).toBeNull();
+  });
+
+  test('renders stored summary sections and regenerate button', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u1' }, status: 'ready' });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        weekStart: '2026-07-27',
+        weekEnd: '2026-08-02',
+        window: {
+          open: false,
+          enforced: true,
+          opensAt: '2026-08-02T10:00:00.000Z',
+          closesAt: '2026-08-02T16:00:00.000Z',
+        },
+        entryCount: 3,
+        minEntries: 2,
         summary: {
           summaryText: 'Escribiste sobre el trabajo y la duda.',
           mainTopics: ['Trabajo'],
@@ -89,6 +131,7 @@ describe('JournalSummary page states', () => {
           socraticText: '¿Qué prueba tienes de eso?',
           machiavelliText:
             '¿Qué posición esperas ganar si sigues evitando el conflicto?',
+          createdAt: '2026-08-02T11:00:00.000Z',
         },
       }),
     });
@@ -111,6 +154,9 @@ describe('JournalSummary page states', () => {
       expect(machiavelliAvatar.getAttribute('src')).toBe(
         '/images/machiavelli.webp',
       );
+      expect(
+        screen.getByRole('button', { name: /REGENERAR RESUMEN/i }),
+      ).toBeTruthy();
     });
   });
 
@@ -121,15 +167,20 @@ describe('JournalSummary page states', () => {
       json: async () => ({
         weekStart: '2026-07-27',
         weekEnd: '2026-08-02',
-        window: { open: true, enforced: false },
+        window: {
+          open: false,
+          enforced: true,
+          opensAt: '2026-08-02T10:00:00.000Z',
+          closesAt: '2026-08-02T16:00:00.000Z',
+        },
         entryCount: 3,
         minEntries: 2,
-        canCreate: false,
         summary: {
           summaryText: 'Escribiste sobre el trabajo y la duda.',
           mainTopics: ['Trabajo'],
           bestQuote: 'Nunca es suficiente',
           socraticText: '¿Qué prueba tienes de eso?',
+          createdAt: '2026-08-02T11:00:00.000Z',
         },
       }),
     });
@@ -160,5 +211,8 @@ describe('JournalSummary page states', () => {
       screen.getByText(/Maybe I don't need a better plan/i),
     ).toBeTruthy();
     expect(apiFetch).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole('button', { name: /REGENERAR RESUMEN/i }),
+    ).toBeNull();
   });
 });

--- a/frontend/src/Pages/Journal/JournalSummaryBanner.jsx
+++ b/frontend/src/Pages/Journal/JournalSummaryBanner.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../Context/AuthContext.jsx';
 import { apiFetch } from '../../api/client.js';
+import { resolveSummaryAvailability } from './summaryAvailability.js';
 
 /**
  * Soft alert when the weekly summary can be created.
@@ -24,7 +25,9 @@ const JournalSummaryBanner = () => {
         const res = await apiFetch('/auth/me/journal-summaries/current');
         if (!res.ok) return;
         const data = await res.json();
-        if (!cancelled) setCanCreate(Boolean(data.canCreate));
+        if (!cancelled) {
+          setCanCreate(resolveSummaryAvailability(data).canCreate);
+        }
       } catch {
         if (!cancelled) setCanCreate(false);
       }

--- a/frontend/src/Pages/Journal/summaryAvailability.js
+++ b/frontend/src/Pages/Journal/summaryAvailability.js
@@ -1,0 +1,36 @@
+/**
+ * Derive create/display state from GET /journal-summaries/current payload.
+ * Gating lives here so the backend stays a pure generator.
+ */
+export const resolveSummaryAvailability = (payload) => {
+  const windowOpen = Boolean(payload?.window?.open);
+  const windowEnforced = Boolean(payload?.window?.enforced);
+  const entryCount = payload?.entryCount ?? 0;
+  const minEntries = payload?.minEntries ?? 2;
+  const serverSummary = payload?.summary ?? null;
+  const opensAtMs = payload?.window?.opensAt
+    ? new Date(payload.window.opensAt).getTime()
+    : null;
+
+  const stale =
+    windowOpen &&
+    serverSummary?.createdAt &&
+    opensAtMs != null &&
+    !Number.isNaN(opensAtMs)
+      ? new Date(serverSummary.createdAt).getTime() < opensAtMs
+      : false;
+
+  const displayedSummary = stale ? null : serverSummary;
+  const canCreate =
+    windowOpen && entryCount >= minEntries && !displayedSummary;
+
+  return {
+    windowOpen,
+    windowEnforced,
+    entryCount,
+    minEntries,
+    stale,
+    displayedSummary,
+    canCreate,
+  };
+};

--- a/frontend/src/Pages/Journal/summaryAvailability.test.js
+++ b/frontend/src/Pages/Journal/summaryAvailability.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+import { resolveSummaryAvailability } from './summaryAvailability.js';
+
+const basePayload = {
+  weekStart: '2026-08-03',
+  weekEnd: '2026-08-09',
+  entryCount: 3,
+  minEntries: 2,
+  window: {
+    open: true,
+    enforced: true,
+    opensAt: '2026-08-09T10:00:00.000Z',
+    closesAt: '2026-08-09T16:00:00.000Z',
+  },
+  summary: null,
+};
+
+describe('resolveSummaryAvailability', () => {
+  test('allows create when window is open, enough entries, and no summary', () => {
+    const result = resolveSummaryAvailability(basePayload);
+    expect(result.canCreate).toBe(true);
+    expect(result.displayedSummary).toBeNull();
+  });
+
+  test('hides stale summary created before the current window opens', () => {
+    const result = resolveSummaryAvailability({
+      ...basePayload,
+      summary: {
+        summaryText: 'Old mid-week summary',
+        createdAt: '2026-08-04T15:00:00.000Z',
+      },
+    });
+    expect(result.stale).toBe(true);
+    expect(result.displayedSummary).toBeNull();
+    expect(result.canCreate).toBe(true);
+  });
+
+  test('keeps a summary created during the current window', () => {
+    const summary = {
+      summaryText: 'Fresh Sunday summary',
+      createdAt: '2026-08-09T11:00:00.000Z',
+    };
+    const result = resolveSummaryAvailability({
+      ...basePayload,
+      summary,
+    });
+    expect(result.stale).toBe(false);
+    expect(result.displayedSummary).toEqual(summary);
+    expect(result.canCreate).toBe(false);
+  });
+
+  test('shows existing summary outside the window without create CTA', () => {
+    const summary = {
+      summaryText: 'Last Sunday summary',
+      createdAt: '2026-08-02T12:00:00.000Z',
+    };
+    const result = resolveSummaryAvailability({
+      ...basePayload,
+      window: {
+        ...basePayload.window,
+        open: false,
+      },
+      summary,
+    });
+    expect(result.canCreate).toBe(false);
+    expect(result.displayedSummary).toEqual(summary);
+  });
+
+  test('blocks create when there are too few entries', () => {
+    const result = resolveSummaryAvailability({
+      ...basePayload,
+      entryCount: 1,
+    });
+    expect(result.canCreate).toBe(false);
+  });
+});

--- a/frontend/src/data/demoJournal.js
+++ b/frontend/src/data/demoJournal.js
@@ -74,12 +74,13 @@ export const DEMO_ENTRIES = [
 export const DEMO_SUMMARY_PAYLOAD = {
   weekStart: '2026-07-27',
   weekEnd: '2026-08-02',
-  canCreate: false,
   entryCount: DEMO_ENTRIES.length,
   minEntries: 2,
   window: {
     open: false,
-    enforced: false,
+    enforced: true,
+    opensAt: '2026-08-02T10:00:00.000Z',
+    closesAt: '2026-08-02T16:00:00.000Z',
   },
   summary: {
     mainTopics: ['Reflexión', 'Sabiduría', 'Preocupaciones'],


### PR DESCRIPTION
## Summary

Restores the Sunday 12:00–18:00 (Madrid) creation window for the weekly journal summary and moves create-gating to the SPA. Adds a temporary "Regenerar" button on the summary page that shares the same generate path, so summaries can be re-created for testing without blocking the next Sunday's create CTA.

## Changes

### Backend (journal summaries)
- `summaryWindow.js`: set `ENFORCE_SUMMARY_WINDOW = true`; fixed `enforcedv` → `enforced` typo in `buildWindowPayload`.
- `journalSummaries.controller.js`: `GET /current` now returns raw `summary` + `window` + `entryCount` + `minEntries` (no `canCreate`). `POST /current` drops the `403`/`409` gates, generates from the week's entries, and **upserts** the row for `(user_id, week_start)` (refreshing `created_at`).
- `journalSummaries.service.js`: added `upsertWeeklySummary` using `ON CONFLICT (user_id, week_start) DO UPDATE ... created_at = NOW()`.
- `summaryWindow.test.js`: renamed the bypass test to reflect enforcement being on by default.

### Frontend (journal summary)
- `summaryAvailability.js` (new): pure helper that derives `windowOpen`, `stale` (`createdAt < window.opensAt` while open), `displayedSummary`, and `canCreate` from the GET payload.
- `JournalSummary.jsx`: uses `resolveSummaryAvailability` for all gating; unifies create + regenerate into one `handleGenerate` (POST); renders a `REGENERAR RESUMEN` button at the bottom of any displayed summary (non-demo only).
- `JournalSummaryBanner.jsx`: derives visibility via `resolveSummaryAvailability` instead of the removed `data.canCreate`.
- `Journal.css`: adds `.journal-page__complete-button--secondary` and `.journal-summary__regenerate` spacing.
- `demoJournal.js`: drops `canCreate`, adds `enforced`/`opensAt`/`closesAt` to the demo payload.
- Tests: new `summaryAvailability.test.js` (5 cases); expanded `JournalSummary.test.jsx` to cover stale-summary hiding, the Regenerar button, and demo-mode absence of Regenerar.

### Docs
- `docs/weekly-journal-summary.md`: updated GET/POST contract, stale-summary rule, dev-bypass note, and success criteria.
- `DECISIONS.md`: records the 2026-08-09 decision to move gating to the SPA and upsert on POST, revisiting the 2026-08-01 server-enforcement decision.

## Notes
- Removing the Regenerar button later restores one-create-per-window UX with no backend changes.
- Accepted risk (documented in DECISIONS.md): an authenticated client can POST outside the window while Regenerar exists. Re-add server `403`/`409` if abuse/cost becomes a concern.
- No DB migration needed; the existing `UNIQUE (user_id, week_start)` constraint backs the upsert.

## Test plan
- [ ] Frontend lint, tests (30), and build pass.
- [ ] Backend lint and tests (25) pass.
- [ ] Outside the window: existing summary shows with Regenerar; no create CTA.
- [ ] Inside the window with a stale (pre-window) summary: summary hidden, create CTA shown.
- [ ] Inside the window after creating: new summary shown with Regenerar; create CTA hidden.
- [ ] Demo mode: summary renders, Regenerar button absent.