### PR TITLE
Split the app into educational and journaling modules

### DIFF
--- a/.cursor/docs/architecture.md
+++ b/.cursor/docs/architecture.md
@@ -51,9 +51,15 @@ The Vite development server is configured on port `3001` in
 
 ### Routing and access
 
-Public routes include onboarding, login, authentication errors, and payment
-results. The rest of the application is nested under `OnboardingGate`, which
-checks the `onboardingRevealed` local-storage flag.
+`/` is the module chooser (`Home`). Shared account and auth routes (`/login`,
+`/auth/error`, `/account`) and the journaling module (`/journal`,
+`/journal/history`, `/journal/summary`) are reachable without onboarding.
+
+The educational module (`/theory`, `/course`, `/session/:sessionId`,
+`/instructions`, `/tests`, `/test/:testId`, `/promo`) is nested under
+`OnboardingGate`, which checks the `onboardingRevealed` local-storage flag.
+`/onboarding` and the payment result pages stay outside the gate to avoid
+redirect loops and to complete Stripe return URLs.
 
 `OnboardingGate` is not an authentication gate. Pages that require an account
 must check `useAuth()` or rely on a protected backend endpoint. Authentication

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -139,3 +139,15 @@ That decision required server-side window enforcement and rejected free regenera
 
 **Operational implications (accepted):**  
 An authenticated client can call POST outside the window (cost/abuse surface). Acceptable while Regenerar exists for testing.
+
+### 2026-08-19 — Split the SPA into educational and journaling modules
+
+**Decision:**  
+Separate the product into two modules behind a homepage chooser at `/`. The educational module (`/theory`, `/course`, `/session/:sessionId`, `/instructions`, `/tests`, `/test/:testId`, `/promo`) remains behind `OnboardingGate`. The journaling module (`/journal`, `/journal/history`, `/journal/summary`) and shared account/auth pages are reachable without onboarding. Each module has its own navigation; a home control returns to `/`. The former article route at `/` moves to `/theory`.
+
+**Why this option was chosen:**  
+This is a product-oriented change that comes from experimentation with the product in the past months. What originally started as an educational-only tool has evolved into a reflection one based on the results of testing the app with online advertisement. Since the journaling features are independent from the original product idea, they are separated at this point, and in the future, based on the results of further testing, the educational module might disappear altogether.
+
+**Why this revisits 2026-01-28:**  
+That decision treated onboarding as a precondition for accessing the app. The gate now guards the educational module only, so journaling can be used and advertised independently.
+

--- a/frontend/public/images/home.svg
+++ b/frontend/public/images/home.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#F4F2F0"><path d="M240-200h120v-240h240v240h120v-360L480-740 240-560v360Zm-80 80v-480l320-240 320 240v480H520v-240h-80v240H160Zm320-350Z"/></svg>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import Tests from './Pages/Tests/Tests.jsx';
 import Journal from './Pages/Journal/Journal.jsx';
 import JournalHistory from './Pages/JournalHistory/JournalHistory.jsx';
 import JournalSummary from './Pages/JournalSummary/JournalSummary.jsx';
+import Home from './Pages/Home/Home.jsx';
 import ScrollToTop from './Components/ScrollToTop/ScrollToTop.jsx';
 import { DemoModeProvider } from './Context/DemoModeContext.jsx';
 
@@ -33,25 +34,29 @@ const App = () => {
                     <DemoModeProvider>
                         <SessionsProvider>
                             <Routes>
-                                <Route path='/onboarding' element={<OnboardingWrapper />} />
+                                {/* Shared */}
+                                <Route path='/' element={<Home />} />
                                 <Route path='/login' element={<Login />} />
                                 <Route path='/auth/error' element={<AuthError />} />
+                                <Route path='/account' element={<Account />} />
+
+                                {/* Journaling module — independent of onboarding */}
+                                <Route path='/journal' element={<Journal />} />
+                                <Route path='/journal/history' element={<JournalHistory />} />
+                                <Route path='/journal/summary' element={<JournalSummary />} />
+
+                                {/* Educational module */}
+                                <Route path='/onboarding' element={<OnboardingWrapper />} />
                                 <Route path='/payment/success' element={<PaymentSuccess />} />
                                 <Route path='/payment/cancel' element={<PaymentCancel />} />
-
-                                {/* Onboarding gate (exclude /onboarding to avoid redirect loop) */}
                                 <Route element={<OnboardingGate />}>
-                                    <Route path='/' element={<ArticleWrapper />} />
-                                    <Route path='course' element={<CourseWrapper />} />
-                                    <Route path='promo' element={<PromoGate />} />
-                                    <Route path='instructions' element={<Instructions />} />
-                                    <Route path='account' element={<Account />} />
-                                    <Route path='tests' element={<Tests />} />
-                                    <Route path='test/:testId' element={<ThoughtsTest />} />
-                                    <Route path='journal/history' element={<JournalHistory />} />
-                                    <Route path='journal/summary' element={<JournalSummary />} />
-                                    <Route path='journal' element={<Journal />} />
-                                    <Route path='session/:sessionId' element={<Session />} />
+                                    <Route path='/theory' element={<ArticleWrapper />} />
+                                    <Route path='/course' element={<CourseWrapper />} />
+                                    <Route path='/session/:sessionId' element={<Session />} />
+                                    <Route path='/instructions' element={<Instructions />} />
+                                    <Route path='/tests' element={<Tests />} />
+                                    <Route path='/test/:testId' element={<ThoughtsTest />} />
+                                    <Route path='/promo' element={<PromoGate />} />
                                 </Route>
                             </Routes>
                         </SessionsProvider>

--- a/frontend/src/Components/Navigation/Navigation.css
+++ b/frontend/src/Components/Navigation/Navigation.css
@@ -75,6 +75,7 @@
     border: 1px solid var(--background);
     border-radius: 12px;
     min-height: 52px;
+    padding: 12px 16px;
     background: transparent;
     color: var(--background);
     font-size: 20px;
@@ -98,6 +99,27 @@
     color: var(--accent);
     font-weight: 700;
     border: 2px solid #F9CB40;
+}
+
+.navigation__menu-link--home {
+    align-self: center;
+    width: 52px;
+    min-height: 52px;
+    padding: 0;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.navigation__menu-link--home:focus-visible {
+    outline: 2px solid var(--background);
+    outline-offset: 2px;
+}
+
+.navigation__menu-home-icon {
+    width: 24px;
+    height: 24px;
 }
 
 @keyframes navigation-menu-slide-in {

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -3,27 +3,26 @@ import './Navigation.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../Context/AuthContext.jsx';
 import { isPromoEnabled } from '../../data/promoConfig.js';
+import {
+    EDUCATIONAL_LINKS,
+    JOURNALING_LINKS,
+    resolveNavModule,
+} from '../../data/navigationModules.js';
 
 const Navigation = () => {
     const [menuState, setMenuState] = useState('closed');
     const navigate = useNavigate();
     const location = useLocation();
     const { user, status } = useAuth();
-    const isCourseRoute = location.pathname.startsWith('/course') || location.pathname.startsWith('/session');
-    const isTestsRoute = location.pathname.startsWith('/tests') || location.pathname.startsWith('/test');
-    const isJournalRoute = location.pathname.startsWith('/journal');
+    const navModule = resolveNavModule(location.pathname);
+    const moduleLinks = navModule === 'journaling' ? JOURNALING_LINKS : EDUCATIONAL_LINKS;
     const isPromoRoute = location.pathname.startsWith('/promo');
     const isAccountRoute = location.pathname.startsWith('/account') || location.pathname.startsWith('/login');
     const menuLinks = [
-        { label: 'TEORÍA', path: '/', isActive: location.pathname === '/' },
-        { label: 'CURSO', path: '/course', isActive: isCourseRoute },
-        { label: 'TESTS', path: '/tests', isActive: isTestsRoute },
-        { label: 'DIARIO', path: '/journal', isActive: isJournalRoute },
-        {
-            label: 'INSTRUCCIONES',
-            path: '/instructions',
-            isActive: location.pathname.startsWith('/instructions'),
-        },
+        ...moduleLinks.map((link) => ({
+            ...link,
+            isActive: link.isActive(location.pathname),
+        })),
         {
             label: user ? 'CUENTA' : 'LOGIN',
             path: user ? '/account' : '/login',
@@ -83,7 +82,7 @@ const Navigation = () => {
                                 {link.label}
                             </button>
                         ))}
-                        {isPromoEnabled() && (
+                        {navModule === 'educational' && isPromoEnabled() && (
                             <button
                                 type='button'
                                 className={`navigation__menu-link navigation__menu-link--promo${isPromoRoute ? ' navigation__menu-link--active' : ''}`}
@@ -92,6 +91,19 @@ const Navigation = () => {
                                 GANA 25€
                             </button>
                         )}
+                        <button
+                            type='button'
+                            className='navigation__menu-link navigation__menu-link--home'
+                            onClick={() => goTo('/')}
+                            aria-label='Inicio'
+                        >
+                            <img
+                                className='navigation__menu-home-icon'
+                                src='/images/home.svg'
+                                alt=''
+                                aria-hidden='true'
+                            />
+                        </button>
                     </div>
                 </div>
             )}
@@ -112,6 +124,6 @@ const Navigation = () => {
             )}
         </>
     );
-}
+};
 
 export default Navigation;

--- a/frontend/src/Components/Navigation/Navigation.test.jsx
+++ b/frontend/src/Components/Navigation/Navigation.test.jsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import Navigation from './Navigation.jsx';
+
+const mockUseLocation = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+    useLocation: () => mockUseLocation(),
+    useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../Context/AuthContext.jsx', () => ({
+    useAuth: () => ({ user: null, status: 'ready' }),
+}));
+
+vi.mock('../../data/promoConfig.js', () => ({
+    isPromoEnabled: () => false,
+}));
+
+const openMenu = () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú' }));
+};
+
+describe('Navigation', () => {
+    beforeEach(() => {
+        mockNavigate.mockReset();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test('shows educational links on an educational route', () => {
+        mockUseLocation.mockReturnValue({ pathname: '/theory' });
+        render(<Navigation />);
+        openMenu();
+
+        expect(screen.getByRole('button', { name: 'TEORÍA' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'CURSO' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'TESTS' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'INSTRUCCIONES' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'LOGIN' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'HISTORIAL' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'RESUMEN SEMANAL' })).toBeNull();
+    });
+
+    test('shows journaling links on a journal route', () => {
+        mockUseLocation.mockReturnValue({ pathname: '/journal' });
+        render(<Navigation />);
+        openMenu();
+
+        expect(screen.getByRole('button', { name: 'DIARIO' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'HISTORIAL' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'RESUMEN SEMANAL' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'LOGIN' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'TEORÍA' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'CURSO' })).toBeNull();
+    });
+
+    test('sends the home control to the module chooser', () => {
+        mockUseLocation.mockReturnValue({ pathname: '/journal/history' });
+        render(<Navigation />);
+        openMenu();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Inicio' }));
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+});

--- a/frontend/src/Pages/Account/Account.css
+++ b/frontend/src/Pages/Account/Account.css
@@ -71,7 +71,7 @@
   bottom: 0;
   z-index: 5;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   max-width: 700px;
   margin: 0 auto;
   border-top: 1px solid var(--background);
@@ -86,16 +86,6 @@
   color: var(--background);
   font-weight: 700;
   letter-spacing: 0.04em;
-}
-
-.account-page__footer-button:first-child::after {
-  content: "";
-  position: absolute;
-  right: 0;
-  top: 15%;
-  bottom: 15%;
-  width: 1px;
-  background: var(--background);
 }
 
 @media (min-width: 1000px) {

--- a/frontend/src/Pages/Account/Account.jsx
+++ b/frontend/src/Pages/Account/Account.jsx
@@ -64,10 +64,7 @@ export default function Account() {
 
       <footer className='account-page__footer-nav'>
         <button type='button' className='account-page__footer-button' onClick={() => navigate('/')}>
-          TEORÍA
-        </button>
-        <button type='button' className='account-page__footer-button' onClick={() => navigate('/course')}>
-          CURSO
+          INICIO
         </button>
       </footer>
     </div>

--- a/frontend/src/Pages/Auth/AuthError.jsx
+++ b/frontend/src/Pages/Auth/AuthError.jsx
@@ -26,10 +26,7 @@ export default function AuthError() {
           Solicitar un nuevo enlace
         </Link>
         <Link className="auth-page__footer-link" to="/">
-          Ir a la teoría
-        </Link>
-        <Link className="auth-page__footer-link" to="/course">
-          Ir al curso
+          Ir al inicio
         </Link>
       </div>
     </div>

--- a/frontend/src/Pages/Auth/Login.jsx
+++ b/frontend/src/Pages/Auth/Login.jsx
@@ -57,10 +57,7 @@ export default function Login() {
               login. Revisa tu bandeja de entrada.
             </p>
             <Link className="auth-page__footer-link" to="/">
-              Ir a la teoría
-            </Link>
-            <Link className="auth-page__footer-link" to="/course">
-              Ir al curso
+              Ir al inicio
             </Link>
           </>
         ) : (
@@ -91,10 +88,7 @@ export default function Login() {
               {loading ? "Enviando…" : "Enviar enlace"}
             </button>
             <Link className="auth-page__footer-link" to="/">
-              Ir a la teoría
-            </Link>
-            <Link className="auth-page__footer-link" to="/course">
-              Ir al curso
+              Ir al inicio
             </Link>
           </form>
         )}

--- a/frontend/src/Pages/Home/Home.css
+++ b/frontend/src/Pages/Home/Home.css
@@ -1,0 +1,38 @@
+.home-page {
+    min-height: 100svh;
+    display: flex;
+    flex-direction: column;
+    background: var(--background);
+}
+
+.home-page__title {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+}
+
+.home-page__button {
+    flex: 1;
+    width: 100%;
+    border-radius: 0;
+    font-size: 28px;
+    letter-spacing: 0.08em;
+}
+
+.home-page__button:focus-visible {
+    outline: 3px solid var(--text);
+    outline-offset: -6px;
+}
+
+.home-page__button--education {
+    background: var(--accent);
+    color: var(--background);
+}
+
+.home-page__button--journal {
+    background: var(--background);
+    color: var(--accent);
+}

--- a/frontend/src/Pages/Home/Home.jsx
+++ b/frontend/src/Pages/Home/Home.jsx
@@ -1,0 +1,28 @@
+import { useNavigate } from 'react-router-dom';
+import './Home.css';
+
+const Home = () => {
+    const navigate = useNavigate();
+
+    return (
+        <main className='home-page'>
+            <h1 className='home-page__title'>Detox Mental</h1>
+            <button
+                type='button'
+                className='home-page__button home-page__button--education'
+                onClick={() => navigate('/theory')}
+            >
+                EDUCACIÓN
+            </button>
+            <button
+                type='button'
+                className='home-page__button home-page__button--journal'
+                onClick={() => navigate('/journal')}
+            >
+                DIARIO
+            </button>
+        </main>
+    );
+};
+
+export default Home;

--- a/frontend/src/Pages/Home/Home.test.jsx
+++ b/frontend/src/Pages/Home/Home.test.jsx
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import Home from './Home.jsx';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => mockNavigate,
+}));
+
+describe('Home', () => {
+    beforeEach(() => {
+        mockNavigate.mockReset();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test('sends EDUCACIÓN to the theory route', () => {
+        render(<Home />);
+        fireEvent.click(screen.getByRole('button', { name: 'EDUCACIÓN' }));
+        expect(mockNavigate).toHaveBeenCalledWith('/theory');
+    });
+
+    test('sends DIARIO to the journal route', () => {
+        render(<Home />);
+        fireEvent.click(screen.getByRole('button', { name: 'DIARIO' }));
+        expect(mockNavigate).toHaveBeenCalledWith('/journal');
+    });
+});

--- a/frontend/src/Pages/Onboarding/Onboarding.jsx
+++ b/frontend/src/Pages/Onboarding/Onboarding.jsx
@@ -316,11 +316,11 @@ export default function Onboarding() {
               className="onboarding__exit-button"
               role="button"
               tabIndex={0}
-              onClick={() => navigate("/")}
+              onClick={() => navigate("/theory")}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  navigate("/");
+                  navigate("/theory");
                 }
               }}
             >

--- a/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
+++ b/frontend/src/Pages/ThoughtsTest/ThoughtsTest.jsx
@@ -223,7 +223,7 @@ function ThoughtsTestChat() {
   }, [phase, loading, stepIndex, test]);
 
   if (!test) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/theory" replace />;
   }
 
   const currentQuestion = test.questions[stepIndex];

--- a/frontend/src/data/navigationModules.js
+++ b/frontend/src/data/navigationModules.js
@@ -1,0 +1,50 @@
+export const EDUCATIONAL_LINKS = [
+    {
+        label: 'TEORÍA',
+        path: '/theory',
+        isActive: (pathname) => pathname === '/theory',
+    },
+    {
+        label: 'CURSO',
+        path: '/course',
+        isActive: (pathname) =>
+            pathname.startsWith('/course') || pathname.startsWith('/session'),
+    },
+    {
+        label: 'TESTS',
+        path: '/tests',
+        isActive: (pathname) =>
+            pathname.startsWith('/tests') || pathname.startsWith('/test'),
+    },
+    {
+        label: 'INSTRUCCIONES',
+        path: '/instructions',
+        isActive: (pathname) => pathname.startsWith('/instructions'),
+    },
+];
+
+export const JOURNALING_LINKS = [
+    {
+        label: 'DIARIO',
+        path: '/journal',
+        isActive: (pathname) => pathname === '/journal',
+    },
+    {
+        label: 'HISTORIAL',
+        path: '/journal/history',
+        isActive: (pathname) => pathname.startsWith('/journal/history'),
+    },
+    {
+        label: 'RESUMEN SEMANAL',
+        path: '/journal/summary',
+        isActive: (pathname) => pathname.startsWith('/journal/summary'),
+    },
+];
+
+export const resolveNavModule = (pathname) => {
+    if (pathname.startsWith('/journal')) {
+        return 'journaling';
+    }
+
+    return 'educational';
+};

--- a/frontend/src/data/navigationModules.test.js
+++ b/frontend/src/data/navigationModules.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import {
+    EDUCATIONAL_LINKS,
+    JOURNALING_LINKS,
+    resolveNavModule,
+} from './navigationModules.js';
+
+describe('resolveNavModule', () => {
+    test('maps journal paths to the journaling module', () => {
+        expect(resolveNavModule('/journal')).toBe('journaling');
+        expect(resolveNavModule('/journal/history')).toBe('journaling');
+        expect(resolveNavModule('/journal/summary')).toBe('journaling');
+    });
+
+    test('maps remaining paths to the educational module', () => {
+        expect(resolveNavModule('/theory')).toBe('educational');
+        expect(resolveNavModule('/course')).toBe('educational');
+        expect(resolveNavModule('/session/1')).toBe('educational');
+        expect(resolveNavModule('/tests')).toBe('educational');
+        expect(resolveNavModule('/test/mind-voice')).toBe('educational');
+        expect(resolveNavModule('/instructions')).toBe('educational');
+    });
+});
+
+describe('module link active matching', () => {
+    const isActive = (links, path, pathname) =>
+        links.find((link) => link.path === path).isActive(pathname);
+
+    test('marks Diario only on the exact journal write path', () => {
+        expect(isActive(JOURNALING_LINKS, '/journal', '/journal')).toBe(true);
+        expect(isActive(JOURNALING_LINKS, '/journal', '/journal/history')).toBe(false);
+        expect(isActive(JOURNALING_LINKS, '/journal/history', '/journal/history')).toBe(true);
+    });
+
+    test('marks Curso for both the course grid and session player', () => {
+        expect(isActive(EDUCATIONAL_LINKS, '/course', '/course')).toBe(true);
+        expect(isActive(EDUCATIONAL_LINKS, '/course', '/session/1')).toBe(true);
+        expect(isActive(EDUCATIONAL_LINKS, '/theory', '/theory')).toBe(true);
+        expect(isActive(EDUCATIONAL_LINKS, '/theory', '/course')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Splits the SPA into two product modules behind a homepage chooser so journaling can be used and advertised independently of the educational course. Theory moves from `/` to `/theory`; onboarding now gates only the educational routes.

## Changes

### Routing
- `/` is a module chooser (`Home`) with EDUCACIÓN → `/theory` and DIARIO → `/journal`.
- Journal routes (`/journal`, `/journal/history`, `/journal/summary`) sit outside `OnboardingGate`.
- Educational routes (`/theory`, `/course`, `/session/:sessionId`, `/instructions`, `/tests`, `/test/:testId`, `/promo`) remain behind the gate.
- Shared auth/account pages stay ungated. Onboarding exit and unknown-test redirects go to `/theory` instead of `/`.

### Navigation
- Menu links come from `navigationModules.js`: educational vs journaling, chosen by path.
- Promo CTA stays educational-only.
- A home control returns to `/`. Account, login, and auth-error footers now link to Inicio instead of Teoría/Curso.

### Docs and tests
- `DECISIONS.md` and architecture docs record the split and the onboarding-gate change.
- Coverage for Home destinations, module resolution, and per-module menu contents.

## Notes
- Bookmarks and links to `/` no longer open the theory article; they hit the chooser.
- Journaling ads/users can skip onboarding entirely.

## Test plan
- [ ] Open `/` and confirm EDUCACIÓN goes to `/theory` and DIARIO goes to `/journal`.
- [ ] With onboarding not revealed, educational routes redirect to onboarding; `/journal`, `/journal/history`, `/journal/summary`, `/login`, and `/account` still load.
- [ ] Complete onboarding and confirm it lands on `/theory`.
- [ ] On `/theory`, the menu shows TEORÍA / CURSO / TESTS / INSTRUCCIONES (and promo if enabled), plus Inicio → `/`.
- [ ] On `/journal`, the menu shows DIARIO / HISTORIAL / RESUMEN SEMANAL, not educational links; Inicio → `/`.
- [ ] Login, auth error, and account footers go to `/`, not theory/course.
- [ ] Opening an invalid test id redirects to `/theory`.